### PR TITLE
feat(ignore-rules): Refactor .gitignore and .athignore handling

### DIFF
--- a/.athignore
+++ b/.athignore
@@ -1,13 +1,21 @@
 ###############################################################################
-# ATHIGNORE - Files and folder in this file are IGNORED and will not appear in
-# the Athanor file explorer nor in the project documentation.
+# ATHIGNORE - Athanor Ignore Rules
 #
-# Uses the same syntax of .gitignore (see https://git-scm.com/docs/gitignore).
+# Files and folders listed in this file will be hidden from the Athanor file
+# explorer and excluded from AI contexts. This file uses the same syntax as 
+# .gitignore (see https://git-scm.com/docs/gitignore).
 #
-# If a file or folder from your project does not appear in the Athanor file 
-# explorer and you would like it to be included, ensure that it is not ignored 
-# by a .athignore rule below by commenting or removing that line.
+# HOW IT WORKS WITH .gitignore: By default, Athanor automatically processes rules 
+# from your project's .gitignore file. This .athignore file is for Athanor-specific 
+# rules or for overriding .gitignore rules.
+#
+# To re-include a file that is ignored by .gitignore, you can add an exception 
+# rule here (e.g., !path/to/file).
+#
+# If you wish to disable the automatic use of .gitignore for this project,
+# you can do so in the project settings.
 ###############################################################################
+
 ###############################################################################
 # GIT SYSTEM FILES
 ###############################################################################
@@ -333,7 +341,7 @@ docs/_site/
 ###############################################################################
 # ATHANOR PROJECT FILES
 ###############################################################################
-.athignore
+
 ###############################################################################
 # PROJECT FILES
 # Add below specific files and folders you want to ignore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 _(Future changes will go here)_
 
+## [0.6.4] - 2025-06-07
+
+### Changed
+
+- **MAJOR CHANGE**: Simplified the project ignore rule handling. Athanor now uses rules from the project's `.gitignore` file by default. The `.athignore` file is now used for Athanor-specific rules or to override `.gitignore` rules, streamlining the initial project setup ([`7020050`](https://github.com/lacerbi/athanor/commit/7020050)).
+
+### Added
+
+- Added a **"Use .gitignore rules"** toggle in **Project Settings**, allowing users to disable the automatic application of `.gitignore` patterns ([`9c8a0d6`](https://github.com/lacerbi/athanor/commit/9c8a0d6)).
+
+### Fixed
+
+- The Project Settings pane now correctly falls back to global default settings instead of using its own hardcoded defaults ([`d831b79`](https://github.com/lacerbi/athanor/commit/d831b79)).
+
+### Documentation
+
+- Updated `PROJECT.md`, `TUTORIAL.md`, and the default `.athignore` header to reflect the new, simplified ignore rule behavior ([`adb73fd`](https://github.com/lacerbi/athanor/commit/adb73fd), [`228a882`](https://github.com/lacerbi/athanor/commit/228a882)).
+
 ## [0.6.3] - 2025-06-06
 
 ### Fixed

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -27,8 +27,8 @@ Athanor is an **Electron-based desktop application** that integrates AI coding a
 
 2.  **Ignore Rules Management**
 
-    - `.athignore` is the primary ignore file used within Athanor.
-    - Rules can be seeded from `.gitignore` during initial setup, ensuring minimal duplication.
+    - By default, Athanor automatically processes rules from the project's `.gitignore` file. This behavior can be toggled in the project settings.
+    - The `.athignore` file is used for Athanor-specific ignore rules or for overriding `.gitignore` rules (e.g., re-including a file with an exception rule like `!path/to/file`).
     - The main process (via `ignoreRulesManager.ts`) uses the `ignore` library to handle advanced wildcard matching, including an 'ignore all by name' option available via the file explorer's context menu.
 
 3.  **Task & Prompt Management**
@@ -49,7 +49,7 @@ Athanor is an **Electron-based desktop application** that integrates AI coding a
 
     - On folder selection, Athanor can create a `.athignore` file if it does not exist.
     - A hidden `.ath_materials` folder is automatically created to store extra references (like doc fragments).
-    - If `.gitignore` exists, its rules can be merged in as an optional step.
+    - If a `.gitignore` file exists, its rules are automatically applied by default.
 
 6.  **User Interface Layout**
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -23,11 +23,12 @@ Here's a step-by-step guide on how to use its main features:
 
 When you first launch Athanor, you'll be prompted to **select a project folder**.
 
-- If your project doesn't have an `.athignore` file (Athanor's specific ignore file), a dialog will appear:
-  - You can choose to create a **default `.athignore` file**, which includes common rules for files and directories (like `node_modules`, `.git`, etc.).
-  - If a `.gitignore` file exists in your project, you'll have the option to **import its rules** into the new `.athignore` file.
-- Once the folder is selected and, if necessary, the `.athignore` file is created, Athanor will scan your project files and display them in the **File Explorer** on the left panel.
-  - Files and folders listed in `.athignore` will **not** appear in the File Explorer.
+- Athanor works with both `.gitignore` and its own `.athignore` file to determine which files to show.
+  - By default, rules from `.gitignore` are automatically used. You can disable this in the **Settings** tab.
+  - The `.athignore` file is for Athanor-specific rules or for overriding `.gitignore` rules (e.g., to re-include an ignored file).
+- If your project doesn't have an `.athignore` file, a dialog will appear asking if you want to create one with a default set of rules for common files (like `node_modules`, `.git`, etc.).
+- Once the folder is selected, Athanor will scan your project files and display them in the **File Explorer** on the left panel.
+  - Files and folders matching the rules in `.gitignore` (if enabled) and `.athignore` will **not** appear.
 - A hidden `.ath_materials` folder is automatically created in your project to store supplementary materials like documentation fragments or project-specific settings.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athanor",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "bugs": {
     "url": "https://github.com/lacerbi/athanor/issues"
   },

--- a/resources/files/default_athignore
+++ b/resources/files/default_athignore
@@ -1,12 +1,19 @@
 ###############################################################################
-# ATHIGNORE - Files and folder in this file are IGNORED and will not appear in
-# the Athanor file explorer nor in the project documentation.
+# ATHIGNORE - Athanor Ignore Rules
 #
-# Uses the same syntax of .gitignore (see https://git-scm.com/docs/gitignore).
+# Files and folders listed in this file will be hidden from the Athanor file
+# explorer and excluded from AI contexts. This file uses the same syntax as 
+# .gitignore (see https://git-scm.com/docs/gitignore).
 #
-# If a file or folder from your project does not appear in the Athanor file 
-# explorer and you would like it to be included, ensure that it is not ignored 
-# by a .athignore rule below by commenting or removing that line.
+# HOW IT WORKS WITH .gitignore: By default, Athanor automatically processes rules 
+# from your project's .gitignore file. This .athignore file is for Athanor-specific 
+# rules or for overriding .gitignore rules.
+#
+# To re-include a file that is ignored by .gitignore, you can add an exception 
+# rule here (e.g., !path/to/file).
+#
+# If you wish to disable the automatic use of .gitignore for this project,
+# you can do so in the project settings.
 ###############################################################################
 
 ###############################################################################
@@ -362,6 +369,3 @@ docs/_site/
 ###############################################################################
 # ATHANOR PROJECT FILES
 ###############################################################################
-
-.athignore
-/athanor.yml

--- a/src/components/AthanorApp.tsx
+++ b/src/components/AthanorApp.tsx
@@ -36,7 +36,6 @@ const AthanorApp: React.FC = () => {
     handleOpenFolder,
     refreshFileSystem,
     showProjectDialog,
-    gitignoreExists,
     pendingDirectory,
     handleCreateProject,
     handleProjectDialogClose,
@@ -181,7 +180,6 @@ const AthanorApp: React.FC = () => {
         isOpen={showProjectDialog}
         onClose={handleProjectDialogClose}
         onCreateProject={handleCreateProject}
-        gitignoreExists={gitignoreExists}
         folderName={pendingDirectory ? getBaseName(pendingDirectory) : ''}
       />
       {filesData && currentDirectory && (

--- a/src/components/ProjectCreationDialog.tsx
+++ b/src/components/ProjectCreationDialog.tsx
@@ -7,8 +7,7 @@ interface ProjectCreationDialogProps {
   isOpen: boolean;
   // Called when user cancels the dialog - should reset dialog state without re-triggering folder selection
   onClose: () => void;
-  onCreateProject: (useStandardIgnore: boolean, importGitignore: boolean) => Promise<void>;
-  gitignoreExists: boolean;
+  onCreateProject: (useStandardIgnore: boolean) => Promise<void>;
   folderName: string;
 }
 
@@ -17,22 +16,16 @@ const ProjectCreationDialog: React.FC<ProjectCreationDialogProps> = ({
   isOpen,
   onClose,
   onCreateProject,
-  gitignoreExists,
 }) => {
   const [useStandardIgnore, setUseStandardIgnore] = useState(true);
-  const [importGitignore, setImportGitignore] = useState(gitignoreExists);
   const [isLoading, setIsLoading] = useState(false);
-
-  useEffect(() => {
-    setImportGitignore(gitignoreExists);
-  }, [gitignoreExists]);
 
   if (!isOpen) return null;
 
   const handleCreate = async () => {
     setIsLoading(true);
     try {
-      await onCreateProject(useStandardIgnore, importGitignore);
+      await onCreateProject(useStandardIgnore);
     } catch (error) {
       console.error('Error creating project:', error);
     } finally {
@@ -50,7 +43,7 @@ const ProjectCreationDialog: React.FC<ProjectCreationDialogProps> = ({
         <div className="bg-blue-50 dark:bg-blue-900/40 border-l-4 border-blue-500 dark:border-blue-500/70 p-4 mb-4">
           <div className="font-medium text-gray-900 dark:text-blue-200">Project Configuration</div>
           <div className="text-sm text-gray-600 dark:text-blue-300/80">
-            Configure how Athanor should handle file ignoring in this project.
+            Athanor will automatically use .gitignore rules if present. You can customize ignore behavior with .athignore for project-specific rules.
           </div>
         </div>
 
@@ -71,30 +64,6 @@ const ProjectCreationDialog: React.FC<ProjectCreationDialogProps> = ({
                 Include default .athignore
               </label>
               <span title="Include a default set of ignore rules for common files and directories like node_modules, .git, etc.">
-                <HelpCircle 
-                  className="h-4 w-4 ml-1 text-gray-400 dark:text-gray-500 cursor-help"
-                />
-              </span>
-            </div>
-          </div>
-
-          <div className="flex items-start space-x-2">
-            <input
-              type="checkbox"
-              id="importGitignore"
-              checked={importGitignore}
-              onChange={(e) => setImportGitignore(e.target.checked)}
-              disabled={!gitignoreExists}
-              className="mt-1 accent-blue-500 dark:accent-blue-400 focus:ring-blue-500 dark:focus:ring-blue-400 dark:focus:ring-offset-gray-800 disabled:opacity-50"
-            />
-            <div className="flex items-center">
-              <label
-                htmlFor="importGitignore"
-                className={`text-sm font-medium leading-none ${!gitignoreExists ? 'text-gray-400 dark:text-gray-500' : 'text-gray-900 dark:text-gray-200'}`}
-              >
-                Import .gitignore options
-              </label>
-              <span title={gitignoreExists ? "Import ignore rules from the existing .gitignore file" : "No .gitignore file found in this folder"}>
                 <HelpCircle 
                   className="h-4 w-4 ml-1 text-gray-400 dark:text-gray-500 cursor-help"
                 />

--- a/src/components/ProjectSettingsPane.tsx
+++ b/src/components/ProjectSettingsPane.tsx
@@ -29,6 +29,7 @@ const ProjectSettingsPane: React.FC<ProjectSettingsPaneProps> = ({
   const [projectNameOverride, setProjectNameOverride] = useState('');
   const [projectInfoFilePath, setProjectInfoFilePath] = useState('');
   const [includeAiSummaries, setIncludeAiSummaries] = useState(true);
+  const [useGitignore, setUseGitignore] = useState(true);
   const [isSavingProject, setIsSavingProject] = useState(false);
   const [projectSaveError, setProjectSaveError] = useState<string | null>(null);
   const [browseError, setBrowseError] = useState<string | null>(null);
@@ -39,11 +40,13 @@ const ProjectSettingsPane: React.FC<ProjectSettingsPaneProps> = ({
       setProjectNameOverride(projectSettings.projectNameOverride || '');
       setProjectInfoFilePath(projectSettings.projectInfoFilePath || '');
       setIncludeAiSummaries(projectSettings.includeAiSummaries ?? true);
+      setUseGitignore(projectSettings.useGitignore ?? true);
     } else {
       // Clear form when no project settings
       setProjectNameOverride('');
       setProjectInfoFilePath('');
       setIncludeAiSummaries(true);
+      setUseGitignore(true);
     }
     // Clear any previous save errors when settings load
     setProjectSaveError(null);
@@ -55,6 +58,7 @@ const ProjectSettingsPane: React.FC<ProjectSettingsPaneProps> = ({
       projectNameOverride?: string;
       projectInfoFilePath?: string;
       includeAiSummaries?: boolean;
+      useGitignore?: boolean;
     }) => {
       if (!currentProjectPath) return;
 
@@ -106,6 +110,12 @@ const ProjectSettingsPane: React.FC<ProjectSettingsPaneProps> = ({
     setIncludeAiSummaries(e.target.checked);
   };
 
+  const handleUseGitignoreChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setUseGitignore(e.target.checked);
+  };
+
   // Handle browse for project info file
   const handleBrowseProjectInfoFile = async () => {
     if (!hasProject) return;
@@ -135,6 +145,7 @@ const ProjectSettingsPane: React.FC<ProjectSettingsPaneProps> = ({
       projectNameOverride: projectNameOverride.trim(),
       projectInfoFilePath: projectInfoFilePath.trim(),
       includeAiSummaries: includeAiSummaries,
+      useGitignore: useGitignore,
     });
   };
 
@@ -142,7 +153,8 @@ const ProjectSettingsPane: React.FC<ProjectSettingsPaneProps> = ({
   const hasUnsavedProjectChanges =
     projectNameOverride !== (projectSettings?.projectNameOverride || '') ||
     projectInfoFilePath !== (projectSettings?.projectInfoFilePath || '') ||
-    includeAiSummaries !== (projectSettings?.includeAiSummaries ?? true);
+    includeAiSummaries !== (projectSettings?.includeAiSummaries ?? true) ||
+    useGitignore !== (projectSettings?.useGitignore ?? true);
 
   return (
     <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 h-fit">
@@ -309,6 +321,40 @@ const ProjectSettingsPane: React.FC<ProjectSettingsPaneProps> = ({
                     className="ml-2 text-sm text-gray-600 dark:text-gray-400"
                   >
                     Add AI summaries at the beginning of files
+                  </label>
+                </div>
+              </div>
+
+              {/* Use Gitignore */}
+              <div className="space-y-2">
+                <div className="flex items-center space-x-2">
+                  <label
+                    htmlFor="useGitignore"
+                    className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    Use .gitignore rules
+                  </label>
+                  <div
+                    className="relative group"
+                    title="When enabled, Athanor automatically applies ignore patterns from .gitignore in the project root. You can use .athignore for Athanor-specific overrides."
+                  >
+                    <HelpCircle className="w-4 h-4 text-gray-400 dark:text-gray-500 cursor-help" />
+                  </div>
+                </div>
+                <div className="flex items-center">
+                  <input
+                    id="useGitignore"
+                    type="checkbox"
+                    checked={useGitignore}
+                    onChange={handleUseGitignoreChange}
+                    disabled={isLoadingProjectSettings || isSavingProject}
+                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded disabled:opacity-50"
+                  />
+                  <label
+                    htmlFor="useGitignore"
+                    className="ml-2 text-sm text-gray-600 dark:text-gray-400"
+                  >
+                    Automatically apply .gitignore patterns
                   </label>
                 </div>
               </div>

--- a/src/components/ProjectSettingsPane.tsx
+++ b/src/components/ProjectSettingsPane.tsx
@@ -5,6 +5,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { HelpCircle, Info } from 'lucide-react';
 import type { ProjectSettings } from '../types/global';
+import { SETTINGS } from '../utils/constants';
 
 interface ProjectSettingsPaneProps {
   projectSettings: ProjectSettings | null;
@@ -39,14 +40,14 @@ const ProjectSettingsPane: React.FC<ProjectSettingsPaneProps> = ({
     if (projectSettings) {
       setProjectNameOverride(projectSettings.projectNameOverride || '');
       setProjectInfoFilePath(projectSettings.projectInfoFilePath || '');
-      setIncludeAiSummaries(projectSettings.includeAiSummaries ?? true);
-      setUseGitignore(projectSettings.useGitignore ?? true);
+      setIncludeAiSummaries(projectSettings.includeAiSummaries ?? SETTINGS.defaults.project.includeAiSummaries);
+      setUseGitignore(projectSettings.useGitignore ?? SETTINGS.defaults.project.useGitignore);
     } else {
       // Clear form when no project settings
       setProjectNameOverride('');
       setProjectInfoFilePath('');
-      setIncludeAiSummaries(true);
-      setUseGitignore(true);
+      setIncludeAiSummaries(SETTINGS.defaults.project.includeAiSummaries);
+      setUseGitignore(SETTINGS.defaults.project.useGitignore);
     }
     // Clear any previous save errors when settings load
     setProjectSaveError(null);
@@ -151,8 +152,8 @@ const ProjectSettingsPane: React.FC<ProjectSettingsPaneProps> = ({
   const hasUnsavedProjectChanges =
     projectNameOverride !== (projectSettings?.projectNameOverride || '') ||
     projectInfoFilePath !== (projectSettings?.projectInfoFilePath || '') ||
-    includeAiSummaries !== (projectSettings?.includeAiSummaries ?? true) ||
-    useGitignore !== (projectSettings?.useGitignore ?? true);
+    includeAiSummaries !== (projectSettings?.includeAiSummaries ?? SETTINGS.defaults.project.includeAiSummaries) ||
+    useGitignore !== (projectSettings?.useGitignore ?? SETTINGS.defaults.project.useGitignore);
 
   return (
     <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 h-fit">

--- a/src/components/ProjectSettingsPane.tsx
+++ b/src/components/ProjectSettingsPane.tsx
@@ -110,9 +110,7 @@ const ProjectSettingsPane: React.FC<ProjectSettingsPaneProps> = ({
     setIncludeAiSummaries(e.target.checked);
   };
 
-  const handleUseGitignoreChange = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
+  const handleUseGitignoreChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUseGitignore(e.target.checked);
   };
 
@@ -292,11 +290,11 @@ const ProjectSettingsPane: React.FC<ProjectSettingsPaneProps> = ({
               </div>
 
               {/* Include AI Summaries */}
-              <div className="space-y-2">
+              <div className="flex items-center justify-between">
                 <div className="flex items-center space-x-2">
                   <label
                     htmlFor="includeAiSummaries"
-                    className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    className="text-sm font-medium text-gray-700 dark:text-gray-300"
                   >
                     Include AI Summaries
                   </label>
@@ -307,56 +305,40 @@ const ProjectSettingsPane: React.FC<ProjectSettingsPaneProps> = ({
                     <HelpCircle className="w-4 h-4 text-gray-400 dark:text-gray-500 cursor-help" />
                   </div>
                 </div>
-                <div className="flex items-center">
-                  <input
-                    id="includeAiSummaries"
-                    type="checkbox"
-                    checked={includeAiSummaries}
-                    onChange={handleIncludeAiSummariesChange}
-                    disabled={isLoadingProjectSettings || isSavingProject}
-                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded disabled:opacity-50"
-                  />
-                  <label
-                    htmlFor="includeAiSummaries"
-                    className="ml-2 text-sm text-gray-600 dark:text-gray-400"
-                  >
-                    Add AI summaries at the beginning of files
-                  </label>
-                </div>
+                <input
+                  id="includeAiSummaries"
+                  type="checkbox"
+                  checked={includeAiSummaries}
+                  onChange={handleIncludeAiSummariesChange}
+                  disabled={isLoadingProjectSettings || isSavingProject}
+                  className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded disabled:opacity-50"
+                />
               </div>
 
               {/* Use Gitignore */}
-              <div className="space-y-2">
+              <div className="flex items-center justify-between">
                 <div className="flex items-center space-x-2">
                   <label
                     htmlFor="useGitignore"
-                    className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    className="text-sm font-medium text-gray-700 dark:text-gray-300"
                   >
                     Use .gitignore rules
                   </label>
                   <div
                     className="relative group"
-                    title="When enabled, Athanor automatically applies ignore patterns from .gitignore in the project root. You can use .athignore for Athanor-specific overrides."
+                    title="When enabled, Athanor automatically applies ignore patterns from .gitignore in the project root. You can use .athignore for additional Athanor-specific overrides."
                   >
                     <HelpCircle className="w-4 h-4 text-gray-400 dark:text-gray-500 cursor-help" />
                   </div>
                 </div>
-                <div className="flex items-center">
-                  <input
-                    id="useGitignore"
-                    type="checkbox"
-                    checked={useGitignore}
-                    onChange={handleUseGitignoreChange}
-                    disabled={isLoadingProjectSettings || isSavingProject}
-                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded disabled:opacity-50"
-                  />
-                  <label
-                    htmlFor="useGitignore"
-                    className="ml-2 text-sm text-gray-600 dark:text-gray-400"
-                  >
-                    Automatically apply .gitignore patterns
-                  </label>
-                </div>
+                <input
+                  id="useGitignore"
+                  type="checkbox"
+                  checked={useGitignore}
+                  onChange={handleUseGitignoreChange}
+                  disabled={isLoadingProjectSettings || isSavingProject}
+                  className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded disabled:opacity-50"
+                />
               </div>
 
               {/* Save Project Settings Button */}

--- a/src/hooks/useFileSystemLifecycle.ts
+++ b/src/hooks/useFileSystemLifecycle.ts
@@ -49,7 +49,6 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
   const [materialsData, setResourcesData] = useState<FileItem | null>(null);
   const [showProjectDialog, setShowProjectDialog] = useState(false);
   const [pendingDirectory, setPendingDirectory] = useState<string | null>(null);
-  const [gitignoreExists, setGitignoreExists] = useState(false);
 
   const refreshTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isInitializedRef = useRef(false);
@@ -110,17 +109,13 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
     [currentDirectory, isRefreshing, validateSelections, addLog]
   );
 
-  const handleCreateProject = async (
-    useStandardIgnore: boolean,
-    importGitignore: boolean
-  ) => {
+  const handleCreateProject = async (useStandardIgnore: boolean) => {
     if (!pendingDirectory) return;
 
     try {
       // Create .athignore file with selected rules
       await createAthignoreFile(pendingDirectory, {
         useStandardIgnore,
-        importGitignore,
       });
 
       // Initialize project with new .athignore
@@ -192,10 +187,6 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
       // Check if .athignore exists
       const athignoreExists = await window.fileService.exists('.athignore');
       if (!athignoreExists) {
-        // Check for .gitignore
-        const hasGitignore = await window.fileService.exists('.gitignore');
-        setGitignoreExists(hasGitignore);
-
         // Show project creation dialog
         setPendingDirectory(normalizedDir);
         setShowProjectDialog(true);
@@ -319,7 +310,6 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
     handleOpenFolder,
     refreshFileSystem,
     showProjectDialog,
-    gitignoreExists,
     pendingDirectory,
     handleCreateProject,
     handleProjectDialogClose,

--- a/src/services/fileIgnoreService.ts
+++ b/src/services/fileIgnoreService.ts
@@ -3,7 +3,6 @@
 // Creates .athignore files with optional standard rules and handles path normalization for ignore patterns.
 interface AthignoreOptions {
   useStandardIgnore: boolean;
-  importGitignore: boolean;
 }
 
 /**
@@ -40,56 +39,6 @@ export async function createAthignoreFile(
     } else {
       // Extract only the initial comment header (everything up to first blank line)
       finalContent = defaultContent.split(/\n\s*\n/)[0] + '\n\n';
-    }
-
-    // If importing from .gitignore and it exists, add those patterns
-    if (options.importGitignore) {
-      const gitignorePath = await window.pathUtils.join(
-        projectPath,
-        '.gitignore'
-      );
-      const exists = await window.fileService.exists(
-        await window.pathUtils.relative(gitignorePath)
-      );
-
-      if (exists) {
-        const gitignoreContent = await window.fileService.read(
-          await window.pathUtils.relative(gitignorePath),
-          { encoding: 'utf8' }
-        ) as string;
-
-        // Get lines from .gitignore
-        const gitignoreLines = gitignoreContent
-          .split('\n')
-          .map((line) => line.trim())
-          .filter((line) => line);
-
-        // Get existing lines from default content if standard ignore is used
-        const existingLines = options.useStandardIgnore
-          ? defaultContent.split('\n').map((line) => line.trim())
-          : [];
-
-        // Filter out duplicates
-        const uniqueGitignoreLines = gitignoreLines.filter(
-          (line) => !existingLines.includes(line)
-        );
-
-        if (uniqueGitignoreLines.length > 0) {
-          // Add .gitignore section header
-          finalContent +=
-            '\n###############################################################################\n';
-          finalContent += '# IMPORTED FROM .gitignore\n';
-          finalContent +=
-            '# These files were imported from .gitignore at creation.\n';
-          finalContent +=
-            '# These are NOT updated automatically if .gitignore is later changed.\n';
-          finalContent +=
-            '###############################################################################\n\n';
-
-          // Add unique lines
-          finalContent += uniqueGitignoreLines.join('\n') + '\n';
-        }
-      }
     }
 
     // Always add the project files section at the end

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -18,6 +18,7 @@ export interface ProjectSettings {
   projectNameOverride?: string;
   projectInfoFilePath?: string;
   includeAiSummaries?: boolean;
+  useGitignore?: boolean;
   // Future expansion: other project-specific settings
 }
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -494,12 +494,8 @@ export interface FileSystemLifecycle {
     newlyCreatedPath?: string
   ) => Promise<void>;
   showProjectDialog: boolean;
-  gitignoreExists: boolean;
   pendingDirectory: string | null;
-  handleCreateProject: (
-    useStandardIgnore: boolean,
-    importGitignore: boolean
-  ) => Promise<void>;
+  handleCreateProject: (useStandardIgnore: boolean) => Promise<void>;
   handleProjectDialogClose: () => void;
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -34,6 +34,7 @@ export const SETTINGS = {
       projectNameOverride: '',
       projectInfoFilePath: '',
       includeAiSummaries: true,
+      useGitignore: true,
     },
     application: {
       enableExperimentalFeatures: false,


### PR DESCRIPTION
# feat(ignore-rules): Refactor .gitignore and .athignore handling

## Summary

This pull request overhauls how Athanor handles file exclusion rules, simplifying the project setup process and making the behavior more intuitive.

Previously, Athanor would copy rules from an existing `.gitignore` file into a new `.athignore` upon project creation. This update changes that core logic. Now, Athanor uses the project's `.gitignore` rules directly by default. The `.athignore` file's role is now clarified: it serves to add Athanor-specific ignore rules or to override `.gitignore` rules (e.g., by using an exception like `!path/to/re-include`).

This change streamlines the initial user experience and aligns Athanor more closely with standard developer tooling.

## Changes Made

-   **Simplified Project Creation**: The project creation dialog (`ProjectCreationDialog.tsx`) has been simplified. It no longer asks to copy rules from `.gitignore`, as this is now the default behavior.
-   **Added `useGitignore` Setting**: A new "Use .gitignore rules" toggle has been added to the **Project Settings** pane (`ProjectSettingsPane.tsx`). This allows users to disable the automatic use of `.gitignore` on a per-project basis. This setting defaults to `true`.
-   **Updated Ignore Logic**: `ignoreRulesManager.ts` now reads rules from `.gitignore` first (if enabled), followed by `.athignore`, allowing for proper overrides.
-   **UI Adjustments**: The layout of checkboxes in the Project Settings pane has been adjusted for better alignment.
-   **Bug Fix**: Corrected an issue in the Project Settings pane where it was using hardcoded default values instead of the global application defaults (`d831b79`).
-   **Documentation**: Updated `PROJECT.md`, `TUTORIAL.md`, and the header of the default `.athignore` file to clearly explain the new, simpler ignore rule handling.

## Testing Done

-   Verified the new project creation flow.
-   Confirmed that a default `.athignore` is created with the updated explanatory header.
-   Tested toggling the "Use .gitignore rules" setting and confirmed that the file explorer correctly reflects changes in ignored files based on both `.gitignore` and `.athignore`.
-   Ensured that adding an exception rule (e.g., `!some/ignored/file`) to `.athignore` correctly re-includes a file that is ignored by `.gitignore`.
-   Confirmed the UI and default settings fix in the Project Settings pane.

## Related Issues

This is related to #27 (a request for dealing with *nested* `.gitignore` files) but it does not fully address it yet. The nested logic will be addressed in the future.