### PR TITLE
feat: Add 'Open Folder' and 'Open Recent' Menu Items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 _(Future changes will go here)_
 
+## [0.6.5] - 2025-06-07
+
+### Added
+
+- "Open Folder" and "Open Recent" menu items for easier project access ([`dba6f4a`](https://github.com/lacerbi/athanor/commit/dba6f4a)).
+
+### Fixed
+
+- Resolved a bug that caused listener leaks and unresponsiveness when using the "Open Folder" menu item ([`bbdf6de`](https://github.com/lacerbi/athanor/commit/bbdf6de)).
+- Corrected a state desynchronization issue between application settings on disk and in-memory state ([`20fac02`](https://github.com/lacerbi/athanor/commit/20fac02)).
+
+### Changed
+
+- Refactored the `useFileSystemLifecycle` hook to prevent excessive IPC listener churn and improve stability ([`e8c9207`](https://github.com/lacerbi/athanor/commit/e8c9207)).
+
+### Tests
+
+- Fixed failing unit tests related to recent bug fixes and refactoring ([`1538b0d`](https://github.com/lacerbi/athanor/commit/1538b0d)).
+
 ## [0.6.4] - 2025-06-07
 
 ### Changed

--- a/electron/handlers/coreHandlers.test.ts
+++ b/electron/handlers/coreHandlers.test.ts
@@ -615,7 +615,6 @@ describe('setupCoreHandlers', () => {
         fs.constants.R_OK | fs.constants.W_OK
       );
       expect(mockFileService.setBaseDir).toHaveBeenCalledWith(unixPath);
-      expect(mockWebContents.send).toHaveBeenCalledWith('fs:folderChanged', unixPath);
     });
 
     it('should handle folder access error', async () => {
@@ -632,7 +631,6 @@ describe('setupCoreHandlers', () => {
       mockFsAccess.mockRejectedValue(new Error('Permission denied'));
 
       await expect(handler(mockEvent)).rejects.toThrow('Cannot access folder: Permission denied');
-      expect(mockWebContents.send).toHaveBeenCalledWith('fs:error', expect.stringContaining('Cannot access folder'));
     });
 
     it('should handle setBaseDir error', async () => {
@@ -650,8 +648,6 @@ describe('setupCoreHandlers', () => {
       mockFileService.setBaseDir.mockRejectedValue(new Error('SetBaseDir error'));
 
       await expect(handler(mockEvent)).rejects.toThrow('SetBaseDir error');
-      // String(error) will produce "Error: SetBaseDir error"
-      expect(mockWebContents.send).toHaveBeenCalledWith('fs:error', 'Error: SetBaseDir error');
     });
 
     it('should handle destroyed webContents gracefully', async () => {

--- a/electron/handlers/coreHandlers.ts
+++ b/electron/handlers/coreHandlers.ts
@@ -239,19 +239,10 @@ export function setupCoreHandlers(
         // (This will handle cleaning up old watchers, reloading ignore rules, etc.)
         await _fileService.setBaseDir(selectedPath);
 
-        // Notify renderer of successful folder change
-        if (mainWindow?.webContents && !mainWindow.webContents.isDestroyed()) {
-          mainWindow.webContents.send('fs:folderChanged', selectedPath);
-        }
-
         return selectedPath;
       }
       return null;
     } catch (error) {
-      // Ensure renderer is notified of errors
-      if (mainWindow?.webContents && !mainWindow.webContents.isDestroyed()) {
-        mainWindow.webContents.send('fs:error', String(error));
-      }
       handleError(error, 'opening folder dialog');
     }
   });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,7 +1,7 @@
 // AI Summary: Main electron process that coordinates window management, file system operations,
 // and IPC communication between processes. Handles application lifecycle events, path resolution,
 // and uncaught exception handling with proper cleanup of file watchers.
-import { app, BrowserWindow, Menu, nativeTheme } from 'electron';
+import { app, BrowserWindow, Menu, nativeTheme, ipcMain } from 'electron';
 import * as path from 'path';
 import { createWindow, mainWindow } from './windowManager';
 import { setupIpcHandlers } from './ipcHandlers';
@@ -19,6 +19,149 @@ export let llmService: LLMServiceMain;
 // Get the base directory of the Athanor application
 export function getAppBasePath(): string {
   return app.getAppPath();
+}
+
+// Dynamic menu builder function
+async function buildMenu() {
+  try {
+    const appSettings = await settingsService.getApplicationSettings();
+    const recentProjects = appSettings?.recentProjectPaths || [];
+
+    const recentProjectsMenu: Electron.MenuItemConstructorOptions[] =
+      recentProjects.length > 0
+        ? recentProjects.map((projectPath) => ({
+            label: projectPath,
+            click: () => {
+              mainWindow?.webContents.send('menu:open-path', projectPath);
+            },
+          }))
+        : [{ label: 'No Recent Projects', enabled: false }];
+
+    // Read package.json for About panel information
+    const packageJson = require('../package.json');
+
+    // Create application menu template
+    const menuTemplate: Electron.MenuItemConstructorOptions[] = [
+      // macOS app menu
+      ...(process.platform === 'darwin'
+        ? [
+            {
+              label: app.getName(),
+              submenu: [
+                { role: 'about' as const },
+                { type: 'separator' as const },
+                { role: 'services' as const },
+                { type: 'separator' as const },
+                { role: 'hide' as const },
+                { role: 'hideOthers' as const },
+                { role: 'unhide' as const },
+                { type: 'separator' as const },
+                { role: 'quit' as const },
+              ] as Electron.MenuItemConstructorOptions[],
+            },
+          ]
+        : []),
+      // File menu
+      {
+        label: 'File',
+        submenu: [
+          {
+            label: 'Open Folder...',
+            accelerator: 'CmdOrCtrl+O',
+            click: () => {
+              mainWindow?.webContents.send('menu:open-folder');
+            },
+          },
+          { type: 'separator' as const },
+          {
+            label: 'Open Recent',
+            submenu: recentProjectsMenu,
+          },
+          { type: 'separator' as const },
+          process.platform === 'darwin'
+            ? { role: 'close' as const }
+            : { role: 'quit' as const },
+        ],
+      },
+      // Edit menu
+      {
+        label: 'Edit',
+        submenu: [
+          { role: 'undo' as const },
+          { role: 'redo' as const },
+          { type: 'separator' as const },
+          { role: 'cut' as const },
+          { role: 'copy' as const },
+          { role: 'paste' as const },
+          ...(process.platform === 'darwin'
+            ? [
+                { role: 'pasteAndMatchStyle' as const },
+                { role: 'delete' as const },
+                { role: 'selectAll' as const },
+                { type: 'separator' as const },
+                {
+                  label: 'Speech',
+                  submenu: [
+                    { role: 'startSpeaking' as const },
+                    { role: 'stopSpeaking' as const },
+                  ],
+                },
+              ]
+            : [
+                { role: 'delete' as const },
+                { type: 'separator' as const },
+                { role: 'selectAll' as const },
+              ]),
+        ],
+      },
+      // View menu
+      {
+        label: 'View',
+        submenu: [
+          { role: 'reload' as const },
+          { role: 'forceReload' as const },
+          { role: 'toggleDevTools' as const },
+          { type: 'separator' as const },
+          { role: 'resetZoom' as const },
+          { role: 'zoomIn' as const },
+          { role: 'zoomOut' as const },
+          { type: 'separator' as const },
+          { role: 'togglefullscreen' as const },
+        ],
+      },
+      // Window menu
+      {
+        label: 'Window',
+        submenu: [
+          { role: 'minimize' as const },
+          { role: 'zoom' as const },
+          ...(process.platform === 'darwin'
+            ? [
+                { type: 'separator' as const },
+                { role: 'front' as const },
+                { type: 'separator' as const },
+                { role: 'window' as const },
+              ]
+            : [{ role: 'close' as const }]),
+        ],
+      },
+      // Help menu
+      {
+        role: 'help' as const,
+        submenu: [
+          {
+            label: `About ${packageJson.name.charAt(0).toUpperCase() + packageJson.name.slice(1)}`,
+            role: 'about' as const,
+          },
+        ],
+      },
+    ];
+
+    const menu = Menu.buildFromTemplate(menuTemplate);
+    Menu.setApplicationMenu(menu);
+  } catch (error) {
+    console.error('Error building menu:', error);
+  }
 }
 
 // App lifecycle handlers
@@ -46,112 +189,9 @@ app.whenReady().then(async () => {
     credits: `${packageJson.description}`,
   });
 
-  // Create application menu
-  const menuTemplate: Electron.MenuItemConstructorOptions[] = [
-    // macOS app menu
-    ...(process.platform === 'darwin'
-      ? [
-          {
-            label: app.getName(),
-            submenu: [
-              { role: 'about' as const },
-              { type: 'separator' as const },
-              { role: 'services' as const },
-              { type: 'separator' as const },
-              { role: 'hide' as const },
-              { role: 'hideOthers' as const },
-              { role: 'unhide' as const },
-              { type: 'separator' as const },
-              { role: 'quit' as const },
-            ] as Electron.MenuItemConstructorOptions[],
-          },
-        ]
-      : []),
-    // File menu
-    {
-      label: 'File',
-      submenu: [
-        process.platform === 'darwin'
-          ? { role: 'close' as const }
-          : { role: 'quit' as const },
-      ],
-    },
-    // Edit menu
-    {
-      label: 'Edit',
-      submenu: [
-        { role: 'undo' as const },
-        { role: 'redo' as const },
-        { type: 'separator' as const },
-        { role: 'cut' as const },
-        { role: 'copy' as const },
-        { role: 'paste' as const },
-        ...(process.platform === 'darwin'
-          ? [
-              { role: 'pasteAndMatchStyle' as const },
-              { role: 'delete' as const },
-              { role: 'selectAll' as const },
-              { type: 'separator' as const },
-              {
-                label: 'Speech',
-                submenu: [
-                  { role: 'startSpeaking' as const },
-                  { role: 'stopSpeaking' as const },
-                ],
-              },
-            ]
-          : [
-              { role: 'delete' as const },
-              { type: 'separator' as const },
-              { role: 'selectAll' as const },
-            ]),
-      ],
-    },
-    // View menu
-    {
-      label: 'View',
-      submenu: [
-        { role: 'reload' as const },
-        { role: 'forceReload' as const },
-        { role: 'toggleDevTools' as const },
-        { type: 'separator' as const },
-        { role: 'resetZoom' as const },
-        { role: 'zoomIn' as const },
-        { role: 'zoomOut' as const },
-        { type: 'separator' as const },
-        { role: 'togglefullscreen' as const },
-      ],
-    },
-    // Window menu
-    {
-      label: 'Window',
-      submenu: [
-        { role: 'minimize' as const },
-        { role: 'zoom' as const },
-        ...(process.platform === 'darwin'
-          ? [
-              { type: 'separator' as const },
-              { role: 'front' as const },
-              { type: 'separator' as const },
-              { role: 'window' as const },
-            ]
-          : [{ role: 'close' as const }]),
-      ],
-    },
-    // Help menu
-    {
-      role: 'help' as const,
-      submenu: [
-        {
-          label: `About ${packageJson.name.charAt(0).toUpperCase() + packageJson.name.slice(1)}`,
-          role: 'about' as const,
-        },
-      ],
-    },
-  ];
-
-  const menu = Menu.buildFromTemplate(menuTemplate);
-  Menu.setApplicationMenu(menu);
+  // Set up menu rebuild listener and build initial menu
+  ipcMain.on('app:rebuild-menu', buildMenu);
+  await buildMenu();
 
   createWindow();
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -50,6 +50,9 @@ contextBridge.exposeInMainWorld('nativeThemeBridge', {
   }
 });
 
+// WARNING: For renderer-side logic, always prefer using actions from the
+// useSettingsStore over calling these IPC functions directly. This ensures the
+// application's in-memory state remains synchronized with the file on disk.
 // Expose settings service API
 contextBridge.exposeInMainWorld('settingsService', {
   getProjectSettings: (projectPath: string) => 
@@ -67,6 +70,9 @@ import { llmServiceRenderer } from './modules/llm/renderer/LLMServiceRenderer';
 
 // Expose secure API key management and LLM service
 contextBridge.exposeInMainWorld('electronBridge', {
+  // WARNING: For renderer-side logic, always prefer using actions from the
+  // relevant Zustand store over calling these IPC functions directly. This ensures the
+  // application's in-memory state remains synchronized with the file on disk.
   secureApiKeyManager: {
     storeKey: (providerId: string, apiKey: string) => 
       ipcRenderer.invoke(IPCChannelNames.SECURE_API_KEY_STORE, { providerId, apiKey }),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -18,8 +18,15 @@ contextBridge.exposeInMainWorld('electron', {
   receive: (channel: string, func: (...args: any[]) => void) => {
     const validChannels = ['fromMain', 'menu:open-folder', 'menu:open-path'];
     if (validChannels.includes(channel)) {
-      ipcRenderer.on(channel, (event, ...args) => func(...args));
+      const listener = (event: any, ...args: any[]) => func(...args);
+      ipcRenderer.on(channel, listener);
+      // Return a cleanup function to remove this specific listener
+      return () => {
+        ipcRenderer.removeListener(channel, listener);
+      };
     }
+    // Return a no-op function if the channel is invalid for safety
+    return () => {};
   },
 });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -10,13 +10,13 @@ const SHOW_CONFIRM_DIALOG_CHANNEL = 'dialog:show-confirm-dialog';
 // Expose protected methods for IPC communication
 contextBridge.exposeInMainWorld('electron', {
   send: (channel: string, data: any) => {
-    const validChannels = ['toMain'];
+    const validChannels = ['toMain', 'app:rebuild-menu'];
     if (validChannels.includes(channel)) {
       ipcRenderer.send(channel, data);
     }
   },
   receive: (channel: string, func: (...args: any[]) => void) => {
-    const validChannels = ['fromMain'];
+    const validChannels = ['fromMain', 'menu:open-folder', 'menu:open-path'];
     if (validChannels.includes(channel)) {
       ipcRenderer.on(channel, (event, ...args) => func(...args));
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athanor",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "bugs": {
     "url": "https://github.com/lacerbi/athanor/issues"
   },

--- a/src/hooks/useFileSystemLifecycle.ts
+++ b/src/hooks/useFileSystemLifecycle.ts
@@ -317,14 +317,14 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
 
   // Set up listeners for menu commands from main process
   useEffect(() => {
-    const openFolderListener = () => handleOpenFolder();
-    window.electron.receive('menu:open-folder', openFolderListener);
+    const cleanupOpenFolder = window.electron.receive('menu:open-folder', () => handleOpenFolder());
+    const cleanupOpenPath = window.electron.receive('menu:open-path', (path: string) => initializeProject(path));
 
-    const openPathListener = (path: string) => initializeProject(path);
-    window.electron.receive('menu:open-path', openPathListener);
-
-    // Note: Cleanup is handled by the preload bridge implementation
-    // The ipcRenderer listeners are managed internally
+    // Return a cleanup function that will be called when the component unmounts
+    return () => {
+      cleanupOpenFolder();
+      cleanupOpenPath();
+    };
   }, [handleOpenFolder, initializeProject]);
 
   const handleProjectDialogClose = () => {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -100,7 +100,7 @@ declare global {
     // Electron bridge for basic IPC communication
     electron: {
       send: (channel: string, data: any) => void;
-      receive: (channel: string, func: (...args: any[]) => void) => void;
+      receive: (channel: string, func: (...args: any[]) => void) => () => void;
     };
 
     // Native theme bridge for system theme detection

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -30,6 +30,7 @@ export interface ApplicationSettings {
   thresholdLineLength?: number;
   lastSelectedApiPresetId?: string | null;
   lastOpenedProjectPath?: string | null;
+  recentProjectPaths?: string[];
   uiTheme?: string;
 
   // Future expansion: more global settings
@@ -94,6 +95,12 @@ declare global {
       getVersion: () => Promise<string>;
       getUserDataPath: () => Promise<string>;
       getInitialPath: () => Promise<string | null>;
+    };
+
+    // Electron bridge for basic IPC communication
+    electron: {
+      send: (channel: string, data: any) => void;
+      receive: (channel: string, func: (...args: any[]) => void) => void;
     };
 
     // Native theme bridge for system theme detection

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -28,6 +28,11 @@ export const SETTINGS = {
   PROJECT_SETTINGS_FILENAME: 'project_settings.json',
   APP_SETTINGS_FILENAME: 'application_settings.json',
   
+  // Configuration limits
+  limits: {
+    MAX_RECENT_PROJECTS: 10,
+  },
+  
   // Default settings
   defaults: {
     project: {
@@ -43,6 +48,7 @@ export const SETTINGS = {
       thresholdLineLength: 200,
       lastSelectedApiPresetId: null,
       lastOpenedProjectPath: undefined,
+      recentProjectPaths: [],
       uiTheme: 'Auto',
     },
   },


### PR DESCRIPTION
# feat: Add 'Open Folder' and 'Open Recent' Menu Items

## Summary

This pull request introduces new menu items for "Open Folder" and "Open Recent" to enhance project accessibility from the application menu. It also includes several critical follow-up fixes and refactors to ensure application stability, addressing bugs related to listener leaks and state management that arose from the new functionality.

## Changes Made

-   **Feature**:
    -   Added "Open Folder" and "Open Recent" options to the application menu for a more intuitive project-opening workflow (`dba6f4a`).

-   **Fixes**:
    -   Resolved a significant bug that caused the application to create multiple listener instances when the "Open Folder" menu was used, leading to potential unresponsiveness and memory leaks (`bbdf6de`).
    -   Corrected a state-disk desynchronization issue by ensuring the `useFileSystemLifecycle` hook correctly utilizes `useSettingsStore` (`20fac02`).

-   **Refactoring**:
    -   Refactored the `useFileSystemLifecycle` hook to prevent IPC listener churn, improving the stability and performance of file system event handling (`e8c9207`).

-   **Tests**:
    -   Updated and fixed failing unit tests to align with the recent bug fixes and refactoring, ensuring test coverage remains robust (`1538b0d`).

-   **Chore**:
    -   Bumped the project version to `0.6.5` (`f544f18`).

## Testing Done

-   All unit tests were updated and are passing (`npm test`).
-   Manually verified that:
    -   The "Open Folder" and "Open Recent" menu items function as expected.
    -   Repeatedly using "Open Folder" does not cause application slowdown or crashes.
    -   Application settings are correctly loaded and synchronized after opening a new project.