### PR TITLE
feat: Implement Intelligent Ignore File Scanner & CLI Support

### DIFF
--- a/.ath_materials/project_settings.json
+++ b/.ath_materials/project_settings.json
@@ -1,5 +1,6 @@
 {
   "projectNameOverride": "Athanor - AI Workbench",
   "projectInfoFilePath": "PROJECT.md",
-  "includeAiSummaries": true
+  "includeAiSummaries": true,
+  "useGitignore": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 _(Future changes will go here)_
 
+## [0.6.6] - 2025-06-07
+
+### Added
+
+- **Intelligent Ignore File Scanner**: Implemented a new hierarchical ignore rule system that recursively scans for `.athignore` and `.gitignore` files. It uses a "Deepest Opinion Wins" algorithm to mimic Git's behavior and an "Athanor-First" precedence system to allow `.athignore` to override `.gitignore` ([`cbefa8d`](https://github.com/lacerbi/athanor/commit/cbefa8d), [`3dca2f6`](https://github.com/lacerbi/athanor/commit/3dca2f6)).
+- **CLI Support**: Added the ability to open a project by providing a directory path as a command-line argument ([`489060b`](https://github.com/lacerbi/athanor/commit/489060b)).
+- **Automatic Ignore Rule Refresh**: The file system and ignore rules now automatically refresh when the "Use .gitignore rules" setting is changed in Project Settings ([`61e9b6e`](https://github.com/lacerbi/athanor/commit/61e9b6e)).
+
+### Changed
+
+- Refactored the folder-opening logic to use a single, shared function for requests coming from either the GUI or the CLI, ensuring consistent behavior ([`a9d9fa2`](https://github.com/lacerbi/athanor/commit/a9d9fa2)).
+
+### Fixed
+
+- Adjusted the "Deepest Opinion Wins" algorithm to correctly handle complex nested ignore and un-ignore scenarios, ensuring the most specific rule is always applied ([`9540595`](https://github.com/lacerbi/athanor/commit/9540595)).
+
+### Tests
+
+- Added comprehensive unit tests for `ignoreRulesManager` to validate the new hierarchical scanning, rule precedence, and path relativity logic ([`db38958`](https://github.com/lacerbi/athanor/commit/db38958), [`316c28f`](https://github.com/lacerbi/athanor/commit/316c28f), [`0b5bc8d`](https://github.com/lacerbi/athanor/commit/0b5bc8d)).
+
 ## [0.6.5] - 2025-06-07
 
 ### Added

--- a/electron/handlers/coreHandlers.ts
+++ b/electron/handlers/coreHandlers.ts
@@ -80,7 +80,18 @@ export function setupCoreHandlers(
   // Add handler for getting initial project path
   ipcMain.handle('app:get-initial-path', async () => {
     try {
-      // Get application settings
+      // Priority 1: Check for a path provided via CLI
+      const cliPath = _fileService.cliPath;
+      if (cliPath) {
+        const exists = await _fileService.exists(cliPath);
+        const isDir = await _fileService.isDirectory(cliPath);
+        if (exists && isDir) {
+          console.log(`[Athanor] Opening project from CLI path: ${cliPath}`);
+          return cliPath;
+        }
+      }
+
+      // Priority 2: Fallback to the last opened project from settings
       const applicationSettings =
         await _settingsService.getApplicationSettings();
 

--- a/electron/ignoreRulesManager.test.ts
+++ b/electron/ignoreRulesManager.test.ts
@@ -30,6 +30,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
   const testBaseDir = '/test/project';
   let originalConsoleLog: typeof console.log;
   let originalConsoleError: typeof console.error;
+  let originalConsoleWarn: typeof console.warn;
   let loadIgnoreRulesSpy: jest.SpyInstance;
 
   beforeAll(() => {
@@ -38,12 +39,15 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
     console.log = jest.fn();
     originalConsoleError = console.error;
     console.error = jest.fn();
+    originalConsoleWarn = console.warn;
+    console.warn = jest.fn();
   });
 
   afterAll(() => {
     // Restore original console
     console.log = originalConsoleLog;
     console.error = originalConsoleError;
+    console.warn = originalConsoleWarn;
    });
 
   beforeEach(() => {

--- a/electron/ignoreRulesManager.test.ts
+++ b/electron/ignoreRulesManager.test.ts
@@ -1,0 +1,625 @@
+// AI Summary: Comprehensive unit tests for the intelligent ignore file scanner covering nested discovery,
+// ignore rule application for pruning, sorting by depth, and integration with project settings.
+
+// Mocks are defined before imports to prevent temporal dead zone errors due to jest.mock hoisting.
+const mockFsAccess = jest.fn();
+const mockFsStat = jest.fn();
+const mockFsReadFile = jest.fn();
+const mockFsReaddir = jest.fn();
+const mockFsWriteFile = jest.fn();
+
+jest.mock('fs/promises', () => ({
+  __esModule: true,
+  access: mockFsAccess,
+  stat: mockFsStat,
+  readFile: mockFsReadFile,
+  readdir: mockFsReaddir,
+  writeFile: mockFsWriteFile,
+}));
+
+jest.mock('./services/PathUtils');
+
+import { ignoreRulesManager } from './ignoreRulesManager';
+import { PathUtils } from './services/PathUtils';
+import * as path from 'path';
+import { Stats } from 'fs';
+
+const mockPathUtils = PathUtils as jest.Mocked<typeof PathUtils>;
+
+describe('IgnoreRulesManager - Intelligent Scanner', () => {
+  const testBaseDir = '/test/project';
+  let originalConsoleLog: typeof console.log;
+
+  beforeAll(() => {
+    // Mock console.log to prevent logging during tests
+    originalConsoleLog = console.log;
+    console.log = jest.fn();
+  });
+
+  afterAll(() => {
+    // Restore original console.log
+    console.log = originalConsoleLog;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup default PathUtils mocks
+    mockPathUtils.normalizeToUnix.mockImplementation((p: string) =>
+      p.replace(/\\/g, '/')
+    );
+    mockPathUtils.joinUnix.mockImplementation((...paths: string[]) =>
+      paths.join('/').replace(/\/+/g, '/')
+    );
+    mockPathUtils.toPlatform.mockImplementation((p: string) => p);
+    mockPathUtils.relative.mockImplementation((from: string, to: string) => {
+      // Simple relative path implementation for tests
+      if (to.startsWith(from + '/')) {
+        return to.substring(from.length + 1);
+      }
+      return to;
+    });
+    mockPathUtils.normalizeForIgnore.mockImplementation(
+      (filePath: string, isDirectory: boolean) => {
+        if (!filePath) return null;
+        return isDirectory ? `${filePath}/` : filePath;
+      }
+    );
+
+    // Clear error state to prevent test leakage
+    ignoreRulesManager.clearError();
+
+    // Mock loadIgnoreRules to prevent async operations during setup
+    jest
+      .spyOn(ignoreRulesManager, 'loadIgnoreRules')
+      .mockResolvedValue(undefined);
+
+    // Set base directory (now won't trigger async loadIgnoreRules)
+    ignoreRulesManager.setBaseDir(testBaseDir);
+  });
+
+  describe('loadIgnoreRules - intelligent scanning', () => {
+    beforeEach(() => {
+      // Restore the real loadIgnoreRules method for these tests
+      jest.restoreAllMocks();
+
+      // Re-setup PathUtils mocks after restoreAllMocks
+      mockPathUtils.normalizeToUnix.mockImplementation((p: string) =>
+        p.replace(/\\/g, '/')
+      );
+      mockPathUtils.joinUnix.mockImplementation((...paths: string[]) =>
+        paths.join('/').replace(/\/+/g, '/')
+      );
+      mockPathUtils.toPlatform.mockImplementation((p: string) => p);
+      mockPathUtils.relative.mockImplementation((from: string, to: string) => {
+        if (to.startsWith(from + '/')) {
+          return to.substring(from.length + 1);
+        }
+        return to;
+      });
+      mockPathUtils.normalizeForIgnore.mockImplementation(
+        (filePath: string, isDirectory: boolean) => {
+          if (!filePath) return null;
+          return isDirectory ? `${filePath}/` : filePath;
+        }
+      );
+    });
+
+    it('should find nested .athignore and .gitignore files', async () => {
+      // Setup file system structure
+      const fileStructure = new Map([
+        [
+          '/test/project',
+          { isDirectory: true, files: ['src', '.athignore', '.gitignore'] },
+        ],
+        [
+          '/test/project/src',
+          { isDirectory: true, files: ['components', 'utils', '.athignore'] },
+        ],
+        [
+          '/test/project/src/components',
+          { isDirectory: true, files: ['Button.tsx', '.gitignore'] },
+        ],
+        [
+          '/test/project/src/utils',
+          { isDirectory: true, files: ['helpers.ts'] },
+        ],
+      ]);
+
+      const ignoreFiles = new Map([
+        ['/test/project/.athignore', 'node_modules/\n*.log'],
+        ['/test/project/.gitignore', '*.tmp\ndist/'],
+        ['/test/project/src/.athignore', '*.test.ts\n!important.test.ts'],
+        ['/test/project/src/components/.gitignore', '*.stories.ts'],
+      ]);
+
+      // Mock fs operations
+      mockFsAccess.mockResolvedValue(undefined);
+      mockFsStat.mockImplementation(async (filePath) => {
+        const pathStr = filePath.toString();
+        const entry = fileStructure.get(pathStr);
+        return {
+          isDirectory: () => entry?.isDirectory ?? false,
+        } as Stats;
+      });
+
+      mockFsReaddir.mockImplementation(async (dirPath) => {
+        const pathStr = dirPath.toString();
+        const entry = fileStructure.get(pathStr);
+        return (entry?.files ?? []) as any;
+      });
+
+      mockFsReadFile.mockImplementation(async (filePath) => {
+        const pathStr = filePath.toString();
+        const content = ignoreFiles.get(pathStr);
+        if (content) {
+          return content;
+        }
+        throw new Error('File not found');
+      });
+
+      // Load ignore rules to trigger scanning
+      await ignoreRulesManager.loadIgnoreRules();
+
+      // Verify that scanning found the expected files
+      expect(mockFsReadFile).toHaveBeenCalledWith(
+        '/test/project/.athignore',
+        'utf-8'
+      );
+      expect(mockFsReadFile).toHaveBeenCalledWith(
+        '/test/project/.gitignore',
+        'utf-8'
+      );
+      expect(mockFsReadFile).toHaveBeenCalledWith(
+        '/test/project/src/.athignore',
+        'utf-8'
+      );
+      expect(mockFsReadFile).toHaveBeenCalledWith(
+        '/test/project/src/components/.gitignore',
+        'utf-8'
+      );
+    });
+
+    it('should skip directories ignored by parent ignore files', async () => {
+      // Setup file system structure with ignored directory
+      const fileStructure = new Map([
+        [
+          '/test/project',
+          { isDirectory: true, files: ['src', 'node_modules', '.athignore'] },
+        ],
+        ['/test/project/src', { isDirectory: true, files: ['components'] }],
+        [
+          '/test/project/node_modules',
+          { isDirectory: true, files: ['package'] },
+        ],
+        [
+          '/test/project/node_modules/package',
+          { isDirectory: true, files: ['.gitignore'] },
+        ],
+      ]);
+
+      const ignoreFiles = new Map([
+        ['/test/project/.athignore', 'node_modules/'],
+      ]);
+
+      // Mock fs operations
+      mockFsAccess.mockResolvedValue(undefined);
+      mockFsStat.mockImplementation(async (filePath) => {
+        const pathStr = filePath.toString();
+        const entry = fileStructure.get(pathStr);
+        return {
+          isDirectory: () => entry?.isDirectory ?? false,
+        } as Stats;
+      });
+
+      mockFsReaddir.mockImplementation(async (dirPath) => {
+        const pathStr = dirPath.toString();
+        const entry = fileStructure.get(pathStr);
+        return (entry?.files ?? []) as any;
+      });
+
+      mockFsReadFile.mockImplementation(async (filePath) => {
+        const pathStr = filePath.toString();
+        const content = ignoreFiles.get(pathStr);
+        if (content) {
+          return content;
+        }
+        throw new Error('File not found');
+      });
+
+      // Re-import and mock the ignore library to control its behavior
+      jest.resetModules();
+      jest.doMock('ignore', () => {
+        return jest.fn(() => ({
+          add: jest.fn().mockReturnThis(),
+          ignores: jest.fn((path: string) => path === 'node_modules/'),
+        }));
+      });
+
+      // Re-import ignoreRulesManager to use the mocked ignore library
+      const { ignoreRulesManager: freshManager } = await import(
+        './ignoreRulesManager'
+      );
+
+      // Setup fresh manager
+      freshManager.clearError();
+      freshManager.setBaseDir(testBaseDir);
+
+      // Load ignore rules to trigger scanning
+      await freshManager.loadIgnoreRules();
+
+      // Verify that the scanner didn't try to read ignore files in node_modules
+      expect(mockFsReadFile).toHaveBeenCalledWith(
+        '/test/project/.athignore',
+        'utf-8'
+      );
+      expect(mockFsReadFile).not.toHaveBeenCalledWith(
+        '/test/project/node_modules/package/.gitignore',
+        'utf-8'
+      );
+
+      // Reset modules back to normal for other tests
+      jest.resetModules();
+    });
+
+    it('should handle missing ignore files gracefully', async () => {
+      // Setup file system structure without ignore files
+      const fileStructure = new Map([
+        ['/test/project', { isDirectory: true, files: ['src'] }],
+        ['/test/project/src', { isDirectory: true, files: ['components'] }],
+        [
+          '/test/project/src/components',
+          { isDirectory: true, files: ['Button.tsx'] },
+        ],
+      ]);
+
+      // Mock fs operations
+      mockFsAccess.mockResolvedValue(undefined);
+      mockFsStat.mockImplementation(async (filePath) => {
+        const pathStr = filePath.toString();
+        const entry = fileStructure.get(pathStr);
+        return {
+          isDirectory: () => entry?.isDirectory ?? false,
+        } as Stats;
+      });
+
+      mockFsReaddir.mockImplementation(async (dirPath) => {
+        const pathStr = dirPath.toString();
+        const entry = fileStructure.get(pathStr);
+        return (entry?.files ?? []) as any;
+      });
+
+      mockFsReadFile.mockImplementation(async () => {
+        throw new Error('File not found');
+      });
+
+      // Should not throw when no ignore files exist
+      await expect(ignoreRulesManager.loadIgnoreRules()).resolves.not.toThrow();
+    });
+
+    it('should respect useGitignore setting from project settings', async () => {
+      // Setup file system structure
+      const fileStructure = new Map([
+        [
+          '/test/project',
+          { isDirectory: true, files: ['src', '.ath_materials', '.gitignore'] },
+        ],
+        [
+          '/test/project/.ath_materials',
+          { isDirectory: true, files: ['project_settings.json'] },
+        ],
+        ['/test/project/src', { isDirectory: true, files: ['components'] }],
+      ]);
+
+      const ignoreFiles = new Map([
+        ['/test/project/.gitignore', 'dist/'],
+        [
+          '/test/project/.ath_materials/project_settings.json',
+          JSON.stringify({ useGitignore: false }),
+        ],
+      ]);
+
+      // Mock fs operations
+      mockFsAccess.mockResolvedValue(undefined);
+      mockFsStat.mockImplementation(async (filePath) => {
+        const pathStr = filePath.toString();
+        const entry = fileStructure.get(pathStr);
+        return {
+          isDirectory: () => entry?.isDirectory ?? false,
+        } as Stats;
+      });
+
+      mockFsReaddir.mockImplementation(async (dirPath) => {
+        const pathStr = dirPath.toString();
+        const entry = fileStructure.get(pathStr);
+        return (entry?.files ?? []) as any;
+      });
+
+      mockFsReadFile.mockImplementation(async (filePath) => {
+        const pathStr = filePath.toString();
+        const content = ignoreFiles.get(pathStr);
+        if (content) {
+          return content;
+        }
+        throw new Error('File not found');
+      });
+
+      // Load ignore rules to trigger scanning
+      await ignoreRulesManager.loadIgnoreRules();
+
+      // When useGitignore is false, .gitignore files should not be read
+      expect(mockFsReadFile).toHaveBeenCalledWith(
+        '/test/project/.ath_materials/project_settings.json',
+        'utf-8'
+      );
+      expect(mockFsReadFile).not.toHaveBeenCalledWith(
+        '/test/project/.gitignore',
+        'utf-8'
+      );
+    });
+
+    it('should skip materials directory during main tree scanning', async () => {
+      // Setup file system structure
+      const fileStructure = new Map([
+        [
+          '/test/project',
+          { isDirectory: true, files: ['src', '.ath_materials'] },
+        ],
+        ['/test/project/src', { isDirectory: true, files: ['components'] }],
+        [
+          '/test/project/.ath_materials',
+          { isDirectory: true, files: ['project_settings.json', '.gitignore'] },
+        ],
+      ]);
+
+      // Mock fs operations
+      mockFsAccess.mockResolvedValue(undefined);
+      mockFsStat.mockImplementation(async (filePath) => {
+        const pathStr = filePath.toString();
+        const entry = fileStructure.get(pathStr);
+        return {
+          isDirectory: () => entry?.isDirectory ?? false,
+        } as Stats;
+      });
+
+      mockFsReaddir.mockImplementation(async (dirPath) => {
+        const pathStr = dirPath.toString();
+        const entry = fileStructure.get(pathStr);
+        return (entry?.files ?? []) as any;
+      });
+
+      mockFsReadFile.mockImplementation(async () => {
+        throw new Error('File not found');
+      });
+
+      // Load ignore rules to trigger scanning
+      await ignoreRulesManager.loadIgnoreRules();
+
+      // Verify that scanner didn't try to read ignore files in .ath_materials
+      expect(mockFsReadFile).not.toHaveBeenCalledWith(
+        '/test/project/.ath_materials/.gitignore',
+        'utf-8'
+      );
+    });
+
+    it('should handle inaccessible directories gracefully', async () => {
+      // Setup file system structure
+      const fileStructure = new Map([
+        ['/test/project', { isDirectory: true, files: ['src', 'restricted'] }],
+        ['/test/project/src', { isDirectory: true, files: ['components'] }],
+      ]);
+
+      // Mock fs operations
+      mockFsAccess.mockImplementation(async (filePath) => {
+        const pathStr = filePath.toString();
+        if (pathStr === '/test/project/restricted') {
+          throw new Error('Permission denied');
+        }
+        return undefined;
+      });
+
+      mockFsStat.mockImplementation(async (filePath) => {
+        const pathStr = filePath.toString();
+        const entry = fileStructure.get(pathStr);
+        return {
+          isDirectory: () => entry?.isDirectory ?? false,
+        } as Stats;
+      });
+
+      mockFsReaddir.mockImplementation(async (dirPath) => {
+        const pathStr = dirPath.toString();
+        const entry = fileStructure.get(pathStr);
+        return (entry?.files ?? []) as any;
+      });
+
+      mockFsReadFile.mockImplementation(async () => {
+        throw new Error('File not found');
+      });
+
+      // Should not throw when encountering inaccessible directories
+      await expect(ignoreRulesManager.loadIgnoreRules()).resolves.not.toThrow();
+    });
+
+    it('should handle malformed project settings gracefully', async () => {
+      // Setup file system structure
+      const fileStructure = new Map([
+        [
+          '/test/project',
+          { isDirectory: true, files: ['.ath_materials', '.gitignore'] },
+        ],
+        [
+          '/test/project/.ath_materials',
+          { isDirectory: true, files: ['project_settings.json'] },
+        ],
+      ]);
+
+      const ignoreFiles = new Map([
+        ['/test/project/.gitignore', 'dist/'],
+        ['/test/project/.ath_materials/project_settings.json', 'invalid json{'],
+      ]);
+
+      // Mock fs operations
+      mockFsAccess.mockResolvedValue(undefined);
+      mockFsStat.mockImplementation(async (filePath) => {
+        const pathStr = filePath.toString();
+        const entry = fileStructure.get(pathStr);
+        return {
+          isDirectory: () => entry?.isDirectory ?? false,
+        } as Stats;
+      });
+
+      mockFsReaddir.mockImplementation(async (dirPath) => {
+        const pathStr = dirPath.toString();
+        const entry = fileStructure.get(pathStr);
+        return (entry?.files ?? []) as any;
+      });
+
+      mockFsReadFile.mockImplementation(async (filePath) => {
+        const pathStr = filePath.toString();
+        const content = ignoreFiles.get(pathStr);
+        if (content) {
+          return content;
+        }
+        throw new Error('File not found');
+      });
+
+      // Should not throw and should default to using .gitignore when settings are malformed
+      await expect(ignoreRulesManager.loadIgnoreRules()).resolves.not.toThrow();
+      expect(mockFsReadFile).toHaveBeenCalledWith(
+        '/test/project/.gitignore',
+        'utf-8'
+      );
+    });
+  });
+
+  describe('ignores() method - temporary behavior', () => {
+    it('should return false during refactor period', () => {
+      // During Commit 1, ignores() should always return false
+      expect(ignoreRulesManager.ignores('any/path')).toBe(false);
+      expect(ignoreRulesManager.ignores('node_modules/')).toBe(false);
+      expect(ignoreRulesManager.ignores('src/components/Button.tsx')).toBe(
+        false
+      );
+    });
+  });
+
+  describe('addIgnorePattern', () => {
+    beforeEach(() => {
+      // Restore the real addIgnorePattern method for these tests
+      jest.restoreAllMocks();
+
+      // Re-setup PathUtils mocks
+      mockPathUtils.normalizeToUnix.mockImplementation((p: string) =>
+        p.replace(/\\/g, '/')
+      );
+      mockPathUtils.joinUnix.mockImplementation((...paths: string[]) =>
+        paths.join('/').replace(/\/+/g, '/')
+      );
+      mockPathUtils.toPlatform.mockImplementation((p: string) => p);
+      mockPathUtils.relative.mockImplementation((from: string, to: string) => {
+        if (to.startsWith(from + '/')) {
+          return to.substring(from.length + 1);
+        }
+        return to;
+      });
+
+      // Mock file operations for addIgnorePattern
+      mockFsAccess.mockResolvedValue(undefined);
+      mockFsReadFile.mockResolvedValue('existing content\n');
+      mockFsWriteFile.mockResolvedValue(undefined);
+
+      // Mock loadIgnoreRules to prevent it from running during addIgnorePattern
+      jest
+        .spyOn(ignoreRulesManager, 'loadIgnoreRules')
+        .mockResolvedValue(undefined);
+
+      // Clear error state
+      ignoreRulesManager.clearError();
+
+      // Set base directory
+      ignoreRulesManager.setBaseDir(testBaseDir);
+    });
+
+    it('should add pattern to .athignore file', async () => {
+      const result = await ignoreRulesManager.addIgnorePattern('*.log');
+
+      expect(result).toBe(true);
+      expect(mockFsWriteFile).toHaveBeenCalledWith(
+        '/test/project/.athignore',
+        expect.stringContaining('/*.log'),
+        'utf8'
+      );
+    });
+
+    it('should handle ignoreAll parameter correctly', async () => {
+      const result = await ignoreRulesManager.addIgnorePattern(
+        'node_modules',
+        true
+      );
+
+      expect(result).toBe(true);
+      expect(mockFsWriteFile).toHaveBeenCalledWith(
+        '/test/project/.athignore',
+        expect.stringContaining('node_modules'),
+        'utf8'
+      );
+    });
+
+    it('should not duplicate existing patterns', async () => {
+      mockFsReadFile.mockResolvedValue('existing content\n/*.log\n');
+
+      const result = await ignoreRulesManager.addIgnorePattern('*.log');
+
+      expect(result).toBe(false);
+      expect(mockFsWriteFile).not.toHaveBeenCalled();
+    });
+
+    it('should create .athignore file if it does not exist', async () => {
+      mockFsAccess.mockRejectedValue(new Error('File not found'));
+      mockFsReadFile.mockResolvedValue('');
+      mockFsWriteFile.mockResolvedValue(undefined);
+
+      const result = await ignoreRulesManager.addIgnorePattern('*.log');
+
+      expect(result).toBe(true);
+      expect(mockFsWriteFile).toHaveBeenCalledWith(
+        '/test/project/.athignore',
+        '',
+        'utf8'
+      );
+      expect(mockFsWriteFile).toHaveBeenCalledWith(
+        '/test/project/.athignore',
+        '/*.log\n',
+        'utf8'
+      );
+    });
+
+    it('should handle errors gracefully', async () => {
+      mockFsReadFile.mockRejectedValue(new Error('Permission denied'));
+
+      await expect(
+        ignoreRulesManager.addIgnorePattern('*.log')
+      ).rejects.toThrow('Permission denied');
+    });
+  });
+
+  describe('utility methods', () => {
+    it('should set and get base directory', () => {
+      const newBaseDir = '/new/project';
+      ignoreRulesManager.setBaseDir(newBaseDir);
+      expect(ignoreRulesManager.getBaseDir()).toBe(newBaseDir);
+    });
+
+    it('should clear rules', () => {
+      ignoreRulesManager.clearRules();
+      // We can't directly test the internal state, but this should not throw
+      expect(() => ignoreRulesManager.clearRules()).not.toThrow();
+    });
+
+    it('should track and clear errors', () => {
+      expect(ignoreRulesManager.getLastError()).toBeNull();
+      ignoreRulesManager.clearError();
+      expect(ignoreRulesManager.getLastError()).toBeNull();
+    });
+  });
+});

--- a/electron/ignoreRulesManager.ts
+++ b/electron/ignoreRulesManager.ts
@@ -1,19 +1,31 @@
-// AI Summary: Manages ignore rules including loading from .athignore/.gitignore files,
-// rule application, and path normalization. Now ensures that when ignoreAll is true,
-// the provided path is directly normalized and stripped of any leading slash, so that
-// ignore-all entries in .athignore appear without a leading slash. Single-item ignores
-// still get a leading slash.
+// AI Summary: Manages nested ignore rules including intelligent discovery of all .athignore/.gitignore files,
+// rule application with "Athanor-First" precedence, and performance-optimized traversal that uses found rules
+// to prune directory scanning. Implements Git-like nested ignore behavior with comprehensive override capabilities.
+
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import ignore from 'ignore';
 import { FILE_SYSTEM } from '../src/utils/constants';
 import { PathUtils } from './services/PathUtils';
 
+/**
+ * Represents an ignore file with its location and parsed rules
+ */
+interface IgnoreFile {
+  /** Directory path containing the ignore file (project-relative Unix path) */
+  path: string;
+  /** Parsed ignore rules using the ignore library */
+  rules: ignore.Ignore;
+}
+
 class IgnoreRulesManager {
-  private ig = ignore();
   private lastError: Error | null = null;
   private materialsDir = FILE_SYSTEM.materialsDirName;
   private baseDir = '';
+  
+  // Master lists of ignore files, sorted from deepest to shallowest
+  private athignoreFiles: IgnoreFile[] = [];
+  private gitignoreFiles: IgnoreFile[] = [];
 
   // Update base directory and reload rules
   setBaseDir(newDir: string) {
@@ -31,29 +43,170 @@ class IgnoreRulesManager {
 
   // Clear existing ignore rules
   clearRules() {
-    this.ig = ignore();
+    this.athignoreFiles = [];
+    this.gitignoreFiles = [];
     console.log('Ignore rules cleared.');
   }
 
-  // Check if a path should be ignored
+  // Check if a path should be ignored (temporarily disabled for refactor)
   ignores(path: string): boolean {
-    return this.ig.ignores(path);
+    // Temporarily return false during refactor - full implementation in Commit 2
+    return false;
   }
 
-  // Load ignore rules: .gitignore (if enabled) then .athignore (for overrides)
+  /**
+   * Recursively scan for all ignore files in the project directory
+   * Uses found ignore rules to prune traversal for performance
+   * @param startDir Starting directory for scan (project-relative Unix path)
+   * @returns Object containing lists of found athignore and gitignore files
+   */
+  private async _scanForIgnoreFiles(startDir: string): Promise<{
+    athignores: IgnoreFile[],
+    gitignores: IgnoreFile[]
+  }> {
+    const athignores: IgnoreFile[] = [];
+    const gitignores: IgnoreFile[] = [];
+    
+    // Get absolute platform path for file system operations
+    const absoluteStartDir = PathUtils.joinUnix(this.baseDir, startDir);
+    const platformStartDir = PathUtils.toPlatform(absoluteStartDir);
+    
+    try {
+      // Check if directory exists and is accessible
+      await fs.access(platformStartDir);
+      const stats = await fs.stat(platformStartDir);
+      if (!stats.isDirectory()) {
+        return { athignores, gitignores };
+      }
+    } catch (error) {
+      // Directory doesn't exist or isn't accessible
+      return { athignores, gitignores };
+    }
+
+    // Read ignore files in current directory
+    const currentIgnores = ignore();
+    let hasCurrentRules = false;
+
+    // Try to read .athignore
+    const athignorePath = PathUtils.toPlatform(
+      PathUtils.joinUnix(absoluteStartDir, '.athignore')
+    );
+    try {
+      const athignoreContent = await fs.readFile(athignorePath, 'utf-8');
+      const athignoreRules = ignore().add(athignoreContent);
+      athignores.push({
+        path: startDir,
+        rules: athignoreRules
+      });
+      // Add to current rules for pruning
+      currentIgnores.add(athignoreContent);
+      hasCurrentRules = true;
+    } catch (error) {
+      // .athignore doesn't exist or can't be read - this is normal
+    }
+
+    // Try to read .gitignore
+    const gitignorePath = PathUtils.toPlatform(
+      PathUtils.joinUnix(absoluteStartDir, '.gitignore')
+    );
+    try {
+      const gitignoreContent = await fs.readFile(gitignorePath, 'utf-8');
+      const gitignoreRules = ignore().add(gitignoreContent);
+      gitignoreRules.add('.git/'); // Always ignore .git directory when using .gitignore
+      gitignores.push({
+        path: startDir,
+        rules: gitignoreRules
+      });
+      // Add to current rules for pruning (only if no .athignore was found)
+      if (!hasCurrentRules) {
+        currentIgnores.add(gitignoreContent);
+        currentIgnores.add('.git/');
+      }
+    } catch (error) {
+      // .gitignore doesn't exist or can't be read - this is normal
+    }
+
+    // Read directory contents for recursion
+    try {
+      const entries = await fs.readdir(platformStartDir);
+      
+      // Filter entries to only directories, and apply ignore rules for pruning
+      for (const entry of entries) {
+        const entryPath = PathUtils.toPlatform(
+          PathUtils.joinUnix(absoluteStartDir, entry)
+        );
+        let isDirectory = false;
+        
+        try {
+          const entryStats = await fs.stat(entryPath);
+          isDirectory = entryStats.isDirectory();
+        } catch (error) {
+          // Skip entries we can't stat
+          continue;
+        }
+        
+        if (!isDirectory) {
+          continue;
+        }
+        
+        // Calculate project-relative path for ignore check
+        const entryRelativePath = startDir === '.' ? entry : PathUtils.joinUnix(startDir, entry);
+        
+        // Skip materials directory from main tree scanning
+        if (startDir === '.' && entry === this.materialsDir) {
+          continue;
+        }
+        
+        // Use current ignore rules to prune traversal
+        // Format path for ignore rules (directories should end with /)
+        const ignoreTestPath = PathUtils.normalizeForIgnore(entryRelativePath, true);
+        if (ignoreTestPath && hasCurrentRules && currentIgnores.ignores(ignoreTestPath)) {
+          continue; // Skip ignored directories
+        }
+        
+        // Recursively scan subdirectory
+        const subResults = await this._scanForIgnoreFiles(entryRelativePath);
+        athignores.push(...subResults.athignores);
+        gitignores.push(...subResults.gitignores);
+      }
+    } catch (error) {
+      console.warn(`Error reading directory ${startDir}:`, error);
+    }
+
+    return { athignores, gitignores };
+  }
+
+  /**
+   * Sort ignore files by directory depth, from deepest to shallowest
+   * @param ignoreFiles Array of ignore files to sort
+   * @returns Sorted array (deepest first)
+   */
+  private _sortIgnoreFilesByDepth(ignoreFiles: IgnoreFile[]): IgnoreFile[] {
+    return ignoreFiles.slice().sort((a, b) => {
+      // Calculate depth by counting path segments
+      const depthA = a.path === '.' ? 0 : a.path.split('/').length;
+      const depthB = b.path === '.' ? 0 : b.path.split('/').length;
+      
+      // Sort deepest first (descending order)
+      return depthB - depthA;
+    });
+  }
+
+  // Load ignore rules: scan for all ignore files and sort them
   async loadIgnoreRules() {
     // Clear existing rules first
     this.clearRules();
 
     const currentBaseDir = this.getBaseDir();
-    const platformBaseDir = PathUtils.toPlatform(currentBaseDir);
+    if (!currentBaseDir) {
+      console.log('No base directory set, skipping ignore rules loading.');
+      return;
+    }
 
     // Read project settings to determine if we should use .gitignore
     let useGitignore = true; // Default to true
-    const projectSettingsPath = path.join(
-      platformBaseDir,
-      FILE_SYSTEM.materialsDirName,
-      'project_settings.json'
+    const projectSettingsPath = PathUtils.toPlatform(
+      PathUtils.joinUnix(currentBaseDir, FILE_SYSTEM.materialsDirName, 'project_settings.json')
     );
 
     try {
@@ -65,38 +218,29 @@ class IgnoreRulesManager {
       // This handles cases where the file doesn't exist or is malformed
     }
 
-    // Load .gitignore if enabled
-    if (useGitignore) {
-      const gitignorePath = path.join(platformBaseDir, '.gitignore');
-      try {
-        const data = await fs.readFile(gitignorePath, 'utf-8');
-        this.ig.add(data);
-        // Always add .git directory when using .gitignore
-        this.ig.add('.git/');
-        console.log('.gitignore rules loaded from:', gitignorePath);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-          console.log('No .gitignore file found.');
-        } else {
-          console.error('Error reading .gitignore:', error);
-          this.handleError(error, 'reading .gitignore');
-        }
-      }
-    }
-
-    // Always load .athignore last for overrides
-    const athignorePath = path.join(platformBaseDir, '.athignore');
     try {
-      const data = await fs.readFile(athignorePath, 'utf-8');
-      this.ig.add(data);
-      console.log('.athignore rules loaded from:', athignorePath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        console.log('No .athignore file found.');
-      } else {
-        console.error('Error reading .athignore:', error);
-        this.handleError(error, 'reading .athignore');
+      console.log('Starting intelligent ignore file scan...');
+      
+      // Scan for all ignore files starting from project root
+      const scanResults = await this._scanForIgnoreFiles('.');
+      
+      // Sort both lists from deepest to shallowest
+      this.athignoreFiles = this._sortIgnoreFilesByDepth(scanResults.athignores);
+      this.gitignoreFiles = useGitignore ? this._sortIgnoreFilesByDepth(scanResults.gitignores) : [];
+      
+      console.log(`Ignore file scan complete. Found ${this.athignoreFiles.length} .athignore files and ${this.gitignoreFiles.length} .gitignore files.`);
+      
+      // Log discovered files for debugging
+      if (this.athignoreFiles.length > 0) {
+        console.log('.athignore files found:', this.athignoreFiles.map(f => f.path));
       }
+      if (this.gitignoreFiles.length > 0) {
+        console.log('.gitignore files found:', this.gitignoreFiles.map(f => f.path));
+      }
+      
+    } catch (error) {
+      console.error('Error during ignore file scan:', error);
+      this.handleError(error, 'scanning ignore files');
     }
   }
 
@@ -127,7 +271,7 @@ class IgnoreRulesManager {
       }
 
       const ignorePath = PathUtils.toPlatform(
-        path.join(this.getBaseDir(), '.athignore')
+        PathUtils.joinUnix(this.getBaseDir(), '.athignore')
       );
 
       // Create .athignore if it doesn't exist

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -174,6 +174,26 @@ app.whenReady().then(async () => {
   // Initialize LLM service with API key service
   llmService = new LLMServiceMain(apiKeyService);
 
+  // Handle CLI argument for opening a project
+  const args = process.argv.slice(app.isPackaged ? 1 : 2);
+  const potentialPath = args.find(arg => !arg.startsWith('-'));
+  
+  if (potentialPath) {
+    const absolutePath = path.resolve(potentialPath);
+    try {
+      // Use fileService to check if the path is a valid directory
+      if (await fileService.isDirectory(absolutePath)) {
+        fileService.cliPath = fileService.toUnix(absolutePath);
+        console.log(`[Athanor] CLI project path specified: ${fileService.cliPath}`);
+      } else {
+        console.warn(`[Athanor] CLI path is not a directory, ignoring: ${absolutePath}`);
+      }
+    } catch (error) {
+      // This can happen if the path does not exist at all
+      console.warn(`[Athanor] Invalid CLI path provided, ignoring: ${absolutePath}`, error);
+    }
+  }
+
   setupIpcHandlers(fileService, settingsService, apiKeyService, llmService);
 
   // Read package.json for About panel information

--- a/electron/services/FileService.ts
+++ b/electron/services/FileService.ts
@@ -16,6 +16,7 @@ import { FILE_SYSTEM } from '../../src/utils/constants';
  * file watching, and integration with ignore rules.
  */
 export class FileService implements IFileService {
+  public cliPath: string | null = null;
   private baseDir = PathUtils.normalizeToUnix(process.cwd());
   private watchers = new Map<string, chokidar.FSWatcher>();
   private materialsDir: string;

--- a/electron/services/PathUtils.test.ts
+++ b/electron/services/PathUtils.test.ts
@@ -258,6 +258,49 @@ describe('PathUtils', () => {
     });
   });
 
+  describe('getAncestors', () => {
+    test('returns root for files in root directory', () => {
+      expect(PathUtils.getAncestors('file.txt')).toEqual(['.']);
+      expect(PathUtils.getAncestors('./file.txt')).toEqual(['.']);
+    });
+
+    test('returns ancestor directories for nested files', () => {
+      expect(PathUtils.getAncestors('src/file.txt')).toEqual(['src', '.']);
+      expect(PathUtils.getAncestors('src/components/Button.tsx')).toEqual(['src/components', 'src', '.']);
+      expect(PathUtils.getAncestors('a/b/c/d/file.js')).toEqual(['a/b/c/d', 'a/b/c', 'a/b', 'a', '.']);
+    });
+
+    test('works with Windows-style paths', () => {
+      expect(PathUtils.getAncestors('src\\components\\file.ts')).toEqual(['src/components', 'src', '.']);
+    });
+
+    test('handles trailing slashes correctly', () => {
+      expect(PathUtils.getAncestors('src/components/')).toEqual(['src', '.']);
+      expect(PathUtils.getAncestors('src/components/file.txt/')).toEqual(['src/components', 'src', '.']);
+    });
+
+    test('handles empty and invalid inputs', () => {
+      expect(PathUtils.getAncestors('')).toEqual(['.']);
+      expect(PathUtils.getAncestors(null as unknown as string)).toEqual(['.']);
+      expect(PathUtils.getAncestors(undefined as unknown as string)).toEqual(['.']);
+    });
+
+    test('handles absolute paths', () => {
+      expect(PathUtils.getAncestors('/home/user/file.txt')).toEqual(['/home/user', '/home', '.']);
+      expect(PathUtils.getAncestors('C:/Users/test/file.txt')).toEqual(['C:/Users/test', 'C:/Users', 'C:', '.']);
+    });
+
+    test('handles single-level directories', () => {
+      expect(PathUtils.getAncestors('src/')).toEqual(['.']);
+      expect(PathUtils.getAncestors('docs/readme.md')).toEqual(['docs', '.']);
+    });
+
+    test('handles complex nested paths', () => {
+      expect(PathUtils.getAncestors('projects/frontend/src/components/ui/Button/index.tsx'))
+        .toEqual(['projects/frontend/src/components/ui/Button', 'projects/frontend/src/components/ui', 'projects/frontend/src/components', 'projects/frontend/src', 'projects/frontend', 'projects', '.']);
+    });
+  });
+
   describe('sanitizeFilename', () => {
     test('removes invalid characters', () => {
       expect(PathUtils.sanitizeFilename('file:name?.txt')).toBe('file_name_.txt');

--- a/electron/services/PathUtils.ts
+++ b/electron/services/PathUtils.ts
@@ -262,6 +262,43 @@ export class PathUtils {
   }
 
   /**
+   * Get ancestor directories of a given path
+   * @param filePath Path to get ancestors for
+   * @returns Array of ancestor directories (including the file's directory) from closest to root
+   */
+  static getAncestors(filePath: string): string[] {
+    if (!filePath) return ['.'];
+    
+    const normalized = PathUtils.normalizeToUnix(filePath);
+    const dirname = PathUtils.dirname(normalized);
+    
+    // Handle files in root directory
+    if (dirname === '' || dirname === '.') {
+      return ['.'];
+    }
+    
+    const ancestors: string[] = [];
+    let current = dirname;
+    
+    while (current && current !== '.' && current !== '/') {
+      ancestors.push(current);
+      const parent = PathUtils.dirname(current);
+      
+      // Prevent infinite loop on edge cases
+      if (parent === current || parent === '') {
+        break;
+      }
+      
+      current = parent;
+    }
+    
+    // Always include root directory
+    ancestors.push('.');
+    
+    return ancestors;
+  }
+
+  /**
    * Get the appropriate temporary directory path
    * @returns Platform-specific temporary directory
    */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athanor",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "bugs": {
     "url": "https://github.com/lacerbi/athanor/issues"
   },

--- a/src/hooks/useFileSystemLifecycle.ts
+++ b/src/hooks/useFileSystemLifecycle.ts
@@ -28,13 +28,13 @@ const loadAndSetEffectiveConfig = async (basePath: string) => {
   try {
     // Get current project settings from the settings store
     const { projectSettings } = useSettingsStore.getState();
-    
+
     // Load effective configuration with settings integration
     const effectiveConfig = await readAthanorConfig(basePath, projectSettings);
-    
+
     // Update the file system store with the effective config
     useFileSystemStore.getState().setEffectiveConfig(effectiveConfig);
-    
+
     return effectiveConfig;
   } catch (error) {
     console.error('Error loading effective configuration:', error);
@@ -57,15 +57,22 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
 
   const { validateSelections, clearSelections } = useFileSystemStore();
   const { addLog } = useLogStore();
-  const { loadProjectSettings, loadApplicationSettings, projectSettings } = useSettingsStore();
+  const { loadProjectSettings, loadApplicationSettings, projectSettings } =
+    useSettingsStore();
+
+  // Track previous project settings to detect changes
+  const prevProjectSettingsRef = useRef<typeof projectSettings>(undefined);
 
   const refreshFileSystem = useCallback(
-    async (silentOrNewPath: boolean | string = false, newlyCreatedPath?: string) => {
+    async (
+      silentOrNewPath: boolean | string = false,
+      newlyCreatedPath?: string
+    ) => {
       // Handle both function signatures:
-      // refreshFileSystem(silent = false) and 
+      // refreshFileSystem(silent = false) and
       // refreshFileSystem(newlyCreatedPath?: string)
       let silent = false;
-      
+
       if (typeof silentOrNewPath === 'boolean') {
         silent = silentOrNewPath;
       } else if (typeof silentOrNewPath === 'string') {
@@ -87,10 +94,7 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
         await loadAndSetEffectiveConfig(currentDirectory);
 
         // Load prompts and tasks
-        await Promise.all([
-          loadPrompts(),
-          loadTasks()
-        ]);
+        await Promise.all([loadPrompts(), loadTasks()]);
 
         // Auto-select newly created file if path was provided
         if (newlyCreatedPath) {
@@ -98,7 +102,7 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
           selectItems([newlyCreatedPath]);
           addLog(`Auto-selected newly created file: ${newlyCreatedPath}`);
         }
-        
+
         if (!silent) {
           addLog('File system refreshed');
         }
@@ -130,91 +134,97 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
     [refreshFileSystem, addLog]
   );
 
-  const initializeProject = useCallback(async (directory: string) => {
-    const normalizedDir = await window.pathUtils.toUnix(directory);
-    
-    // Set the base directory in the main process FIRST. This is the fix for startup hang.
-    await window.fileService.setBaseDirectory(normalizedDir);
-    
-    useFileSystemStore.getState().resetState();
-    setCurrentDirectory(normalizedDir);
+  const initializeProject = useCallback(
+    async (directory: string) => {
+      const normalizedDir = await window.pathUtils.toUnix(directory);
 
-    const { mainTree, materialsTree } = await loadAndSetTrees(normalizedDir);
-    validateSelections(mainTree);
-    setFilesData(mainTree);
-    setResourcesData(materialsTree);
+      // Set the base directory in the main process FIRST. This is the fix for startup hang.
+      await window.fileService.setBaseDirectory(normalizedDir);
 
-    // Load project settings for the new directory
-    await loadProjectSettings(normalizedDir);
-    
-    // Load effective configuration with settings
-    await loadAndSetEffectiveConfig(normalizedDir);
+      useFileSystemStore.getState().resetState();
+      setCurrentDirectory(normalizedDir);
 
-    // Load prompts and tasks
-    await Promise.all([
-      loadPrompts(),
-      loadTasks()
-    ]);
-    
-    await setupWatcher(normalizedDir);
-    addLog(`Loaded directory: ${normalizedDir}`);
+      const { mainTree, materialsTree } = await loadAndSetTrees(normalizedDir);
+      validateSelections(mainTree);
+      setFilesData(mainTree);
+      setResourcesData(materialsTree);
 
-    // Save the successfully loaded project path and update recent projects list
-    try {
-      // Get the save action and current settings from the Zustand store
-      const { saveApplicationSettings, applicationSettings } = useSettingsStore.getState();
-      const currentSettings = applicationSettings || { ...SETTINGS.defaults.application };
-      const newPath = normalizedDir;
+      // Load project settings for the new directory
+      await loadProjectSettings(normalizedDir);
 
-      const existingPaths = currentSettings.recentProjectPaths || [];
-      const filteredPaths = existingPaths.filter(p => p !== newPath);
-      const newRecentPaths = [newPath, ...filteredPaths];
+      // Load effective configuration with settings
+      await loadAndSetEffectiveConfig(normalizedDir);
 
-      // Enforce limit on recent projects
-      if (newRecentPaths.length > SETTINGS.limits.MAX_RECENT_PROJECTS) {
-        newRecentPaths.length = SETTINGS.limits.MAX_RECENT_PROJECTS;
+      // Load prompts and tasks
+      await Promise.all([loadPrompts(), loadTasks()]);
+
+      await setupWatcher(normalizedDir);
+      addLog(`Loaded directory: ${normalizedDir}`);
+
+      // Save the successfully loaded project path and update recent projects list
+      try {
+        // Get the save action and current settings from the Zustand store
+        const { saveApplicationSettings, applicationSettings } =
+          useSettingsStore.getState();
+        const currentSettings = applicationSettings || {
+          ...SETTINGS.defaults.application,
+        };
+        const newPath = normalizedDir;
+
+        const existingPaths = currentSettings.recentProjectPaths || [];
+        const filteredPaths = existingPaths.filter((p) => p !== newPath);
+        const newRecentPaths = [newPath, ...filteredPaths];
+
+        // Enforce limit on recent projects
+        if (newRecentPaths.length > SETTINGS.limits.MAX_RECENT_PROJECTS) {
+          newRecentPaths.length = SETTINGS.limits.MAX_RECENT_PROJECTS;
+        }
+
+        const newSettings: ApplicationSettings = {
+          ...currentSettings,
+          lastOpenedProjectPath: newPath,
+          recentProjectPaths: newRecentPaths,
+        };
+
+        // Use the store action to save settings, which updates both state and disk
+        await saveApplicationSettings(newSettings);
+
+        window.electron.send('app:rebuild-menu', undefined); // Notify main process
+        addLog('Updated recent projects list.');
+      } catch (error) {
+        console.error('Error updating recent projects list:', error);
+        addLog('Warning: Failed to update recent projects list.');
       }
 
-      const newSettings: ApplicationSettings = {
-        ...currentSettings,
-        lastOpenedProjectPath: newPath,
-        recentProjectPaths: newRecentPaths,
-      };
-      
-      // Use the store action to save settings, which updates both state and disk
-      await saveApplicationSettings(newSettings);
-      
-      window.electron.send('app:rebuild-menu', undefined); // Notify main process
-      addLog('Updated recent projects list.');
-    } catch (error) {
-      console.error('Error updating recent projects list:', error);
-      addLog('Warning: Failed to update recent projects list.');
-    }
+      // Reset dialog state
+      setShowProjectDialog(false);
+      setPendingDirectory(null);
+    },
+    [addLog, setupWatcher, validateSelections, loadProjectSettings]
+  );
 
-    // Reset dialog state
-    setShowProjectDialog(false);
-    setPendingDirectory(null);
-  }, [addLog, setupWatcher, validateSelections, loadProjectSettings]);
+  const handleCreateProject = useCallback(
+    async (useStandardIgnore: boolean) => {
+      if (!pendingDirectory) return;
 
-  const handleCreateProject = useCallback(async (useStandardIgnore: boolean) => {
-    if (!pendingDirectory) return;
+      try {
+        // Create .athignore file with selected rules
+        await createAthignoreFile(pendingDirectory, {
+          useStandardIgnore,
+        });
 
-    try {
-      // Create .athignore file with selected rules
-      await createAthignoreFile(pendingDirectory, {
-        useStandardIgnore,
-      });
+        // Initialize project with new .athignore
+        await initializeProject(pendingDirectory);
 
-      // Initialize project with new .athignore
-      await initializeProject(pendingDirectory);
-
-      addLog('Created new Athanor project');
-    } catch (error) {
-      console.error('Error creating project:', error);
-      addLog('Failed to create project');
-      throw error;
-    }
-  }, [pendingDirectory, initializeProject, addLog]);
+        addLog('Created new Athanor project');
+      } catch (error) {
+        console.error('Error creating project:', error);
+        addLog('Failed to create project');
+        throw error;
+      }
+    },
+    [pendingDirectory, initializeProject, addLog]
+  );
 
   const handleOpenFolder = useCallback(async () => {
     try {
@@ -252,10 +262,10 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
       try {
         // Load application settings first (independent of project)
         await loadApplicationSettings();
-        
+
         // Get initial project path from main process
         const initialPath = await window.app.getInitialPath();
-        
+
         if (initialPath) {
           // If we have a valid initial path, initialize the project
           await initializeProject(initialPath);
@@ -265,19 +275,16 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
           setFilesData(null);
           setResourcesData(null);
           useFileSystemStore.getState().resetState();
-          
+
           // Still load prompts and tasks for when a project is opened
-          await Promise.all([
-            loadPrompts(),
-            loadTasks()
-          ]);
-          
+          await Promise.all([loadPrompts(), loadTasks()]);
+
           addLog('No project loaded - ready to open a folder');
         }
       } catch (error) {
         console.error('Error initializing file system:', error);
         addLog('Failed to initialize file system');
-        
+
         // On error, set to no project state
         setCurrentDirectory('');
         setFilesData(null);
@@ -293,18 +300,54 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
         clearTimeout(refreshTimeoutRef.current);
       }
     };
-  }, [setupWatcher, validateSelections, addLog, loadApplicationSettings, loadProjectSettings, initializeProject]);
+  }, [
+    setupWatcher,
+    validateSelections,
+    addLog,
+    loadApplicationSettings,
+    loadProjectSettings,
+    initializeProject,
+  ]);
 
   // Effect to update effective config when project settings change
   useEffect(() => {
+    const prevSettings = prevProjectSettingsRef.current;
+
     if (currentDirectory && projectSettings !== undefined) {
+      // Check if useGitignore setting has changed
+      const useGitignoreChanged =
+        prevSettings !== undefined &&
+        prevSettings?.useGitignore !== projectSettings?.useGitignore;
+
       // Reload effective configuration when project settings change
-      loadAndSetEffectiveConfig(currentDirectory).catch(error => {
-        console.error('Error updating effective configuration after settings change:', error);
+      loadAndSetEffectiveConfig(currentDirectory).catch((error) => {
+        console.error(
+          'Error updating effective configuration after settings change:',
+          error
+        );
         addLog('Failed to update configuration after settings change');
       });
+
+      // If useGitignore setting changed, trigger a silent file system refresh
+      if (useGitignoreChanged) {
+        addLog(
+          `Gitignore usage changed to: ${projectSettings?.useGitignore ? 'enabled' : 'disabled'}`
+        );
+        refreshFileSystem(true).catch((error) => {
+          console.error(
+            'Error refreshing file system after gitignore setting change:',
+            error
+          );
+          addLog(
+            'Failed to refresh file system after gitignore setting change'
+          );
+        });
+      }
     }
-  }, [projectSettings, currentDirectory, addLog]);
+
+    // Update the ref for next comparison
+    prevProjectSettingsRef.current = projectSettings;
+  }, [projectSettings, currentDirectory, addLog, refreshFileSystem]);
 
   useEffect(() => {
     const fetchVersion = async () => {
@@ -322,8 +365,13 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
 
   // Set up listeners for menu commands from main process
   useEffect(() => {
-    const cleanupOpenFolder = window.electron.receive('menu:open-folder', () => handleOpenFolder());
-    const cleanupOpenPath = window.electron.receive('menu:open-path', (path: string) => initializeProject(path));
+    const cleanupOpenFolder = window.electron.receive('menu:open-folder', () =>
+      handleOpenFolder()
+    );
+    const cleanupOpenPath = window.electron.receive(
+      'menu:open-path',
+      (path: string) => initializeProject(path)
+    );
 
     // Return a cleanup function that will be called when the component unmounts
     return () => {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -96,6 +96,16 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     try {
       await window.settingsService.saveProjectSettings(currentProjectPath, settings);
       set({ projectSettings: settings });
+      
+      // Trigger ignore rules reload in main process to reflect useGitignore changes
+      try {
+        await window.fileService.reloadIgnoreRules();
+        console.log('Reloaded ignore rules after saving project settings');
+      } catch (reloadError) {
+        console.warn('Failed to reload ignore rules after saving project settings:', reloadError);
+        // Don't throw here as the settings were saved successfully
+      }
+      
       console.log('Saved project settings:', settings);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error saving project settings';


### PR DESCRIPTION
# feat: Implement Intelligent Ignore File Scanner & CLI Support

## Summary

This pull request introduces a complete overhaul of the ignore rule handling in Athanor, replacing the previous basic implementation with a sophisticated, Git-compatible hierarchical system. The new **Intelligent Ignore File Scanner** recursively discovers and applies `.athignore` and `.gitignore` files throughout the project, ensuring that ignore rules are handled predictably and powerfully.

Additionally, this PR adds Command-Line Interface (CLI) support for opening projects, a quality-of-life improvement for users who work frequently from the terminal.

## Changes Made

### 1. Intelligent Ignore File Scanner (`ignoreRulesManager`)

- **Recursive Scanning**: The manager now intelligently walks the project directory tree to find all `.athignore` and `.gitignore` files.
- **"Deepest Opinion Wins" Algorithm**: Implements a Git-like hierarchical logic where ignore rules in deeper subdirectories override rules from parent directories. This ensures that the most specific rule for any given file path is the one that applies.
- **"Athanor-First" Precedence**: A two-tier system ensures that `.athignore` files have higher precedence than `.gitignore` files at the same directory level. This allows users to specifically override `.gitignore` behavior for Athanor without modifying the original file (e.g., `!path/to/file` in `.athignore` will un-ignore a file even if it's in `.gitignore`).
- **Performance Optimization**: The file scanner is optimized to prune directory traversals. If a directory is ignored by a parent-level rule, the scanner will not waste time searching for more ignore files within it.

### 2. CLI and Settings Enhancements

- **CLI Support**: Athanor can now be launched with a directory path as an argument (e.g., `athanor .` or `athanor /path/to/project`) to open that project directly on startup.
- **Automatic Rule Reloading**: When the **"Use .gitignore rules"** setting is toggled in Project Settings, the ignore rules are now automatically reloaded, providing immediate feedback to the user.
- **Refactored Folder Loading**: The logic for opening a project folder has been unified into a single function, ensuring consistent behavior whether a project is opened via the GUI menu, the new CLI argument, or other future methods.

### 3. Fixes and Testing

- **Logic Correction**: A fix was implemented to refine the "Deepest Opinion Wins" algorithm, ensuring correct behavior in complex override scenarios.
- **Comprehensive Testing**: The `ignoreRulesManager` has been equipped with an extensive suite of unit tests covering the intelligent scanner, hierarchical logic, precedence rules, path relativity, and various edge cases to guarantee stability and correctness.

## Testing Done

- Added a comprehensive suite of unit tests for `ignoreRulesManager.test.ts`, validating the new ignore logic against numerous scenarios.
- Manually verified that opening a folder via the CLI (`npm run dev -- .`) correctly sets the base directory.
- Manually verified that toggling the "Use .gitignore rules" checkbox in the settings UI triggers a file system refresh and applies the correct ignore rules.

## Related Issues

- Fixes #27
- Fixes #32