### PR TITLE
fix: Prevent file selection from resetting on tab switch or refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 _(Future changes will go here)_
 
+## [0.6.8] - 2025-06-08
+
+### Fixed
+
+- Resolved a critical bug where the user's file selection was incorrectly cleared when switching between main application tabs or when the file system refreshed ([`72bc205`](https://github.com/lacerbi/athanor/commit/72bc205)).
+
 ## [0.6.7] - 2025-06-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athanor",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "bugs": {
     "url": "https://github.com/lacerbi/athanor/issues"
   },

--- a/src/components/AthanorApp.tsx
+++ b/src/components/AthanorApp.tsx
@@ -128,15 +128,6 @@ const AthanorApp: React.FC = () => {
     setLastTabChangeTime(Date.now());
   };
 
-  // Handle tab change side effects
-  useEffect(() => {
-    if (activeTab !== 'workbench' && lastTabChangeTime > 0) {
-      const timeSinceLastChange = Date.now() - lastTabChangeTime;
-      if (timeSinceLastChange < 100) {
-        refreshFileSystem(true);
-      }
-    }
-  }, [activeTab, lastTabChangeTime, refreshFileSystem]);
 
   // Show welcome screen when no project is loaded
   if (!currentDirectory && !showProjectDialog) {

--- a/src/hooks/useFileSystemLifecycle.ts
+++ b/src/hooks/useFileSystemLifecycle.ts
@@ -87,8 +87,6 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
         await window.fileService.reloadIgnoreRules();
         const { mainTree, materialsTree } =
           await loadAndSetTrees(currentDirectory);
-        // Clear selections for active tab when file tree changes
-        clearFileSelection();
         setFilesData(mainTree);
         setResourcesData(materialsTree);
 
@@ -201,7 +199,7 @@ export function useFileSystemLifecycle(): FileSystemLifecycle {
       setShowProjectDialog(false);
       setPendingDirectory(null);
     },
-    [addLog, setupWatcher, loadProjectSettings]
+    [addLog, setupWatcher, loadProjectSettings, clearFileSelection]
   );
 
   // Centralized function to process a directory - handles both UI and CLI flows


### PR DESCRIPTION
# fix: Prevent file selection from resetting on tab switch or refresh

## Summary

This pull request resolves a critical bug that caused the user's list of selected files to be cleared whenever they switched between the main application tabs (e.g., from "Workbench" to "Apply Changes") or when the file system was refreshed.

The root cause was twofold:
1.  A `useEffect` in `AthanorApp.tsx` incorrectly triggered a file system refresh during a simple UI tab switch.
2.  The `refreshFileSystem` function in `useFileSystemLifecycle.ts` destructively cleared the active tab's file selection, erasing user state during what should have been a background data update.

This fix addresses both issues, making the application more robust and preserving the user's selection state as expected.

## Changes Made

-   **`fix(useFileSystemLifecycle)`**: The `refreshFileSystem` function in the `useFileSystemLifecycle` hook has been corrected. It no longer calls `clearFileSelection()`, ensuring that refreshing the file tree is a non-destructive operation on the UI's selection state.
-   **`refactor(AthanorApp)`**: Removed the erroneous `useEffect` from `AthanorApp.tsx` that triggered a file system refresh on a tab change. This decouples UI navigation from backend file system operations, improving predictability and performance.
-   **`fix(useFileSystemLifecycle)`**: Corrected the dependency array for the `initializeProject` `useCallback` to include `clearFileSelection`, adhering to React's rules of hooks and preventing potential stale closures.

## Testing Done

-   Manually selected several files in the "Workbench" tab.
-   Switched to the "File Viewer" and "Apply Changes" tabs and then back to the "Workbench" tab.
-   **Result:** The list of selected files correctly persisted.
-   Triggered a manual file system refresh using the refresh button.
-   **Result:** The file tree updated, and the list of selected files correctly persisted.