### PR TITLE
refactor: Implement Git-Consistent Nested Ignore Rule Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 _(Future changes will go here)_
 
+## [0.7.1] - 2025-06-20
+
+### Fixed
+
+- Corrected the handling of nested `.gitignore` and `.athignore` files. Ignore patterns are now properly scoped to their containing directory, ensuring file exclusion behavior is consistent with Git's handling of path-relative rules. ([52d42a5](https://github.com/lacerbi/athanor/commit/52d42a5), [4286566](https://github.com/lacerbi/athanor/commit/4286566))
+
 ## [0.7.0] - 2025-06-20
 
 ### Added

--- a/electron/__tests__/mockFsHelpers.ts
+++ b/electron/__tests__/mockFsHelpers.ts
@@ -1,0 +1,93 @@
+// AI Summary: Provides mock implementations and setup utilities for file system operations in Jest tests.
+// Exports setupMockFs to simulate a file structure and clearMockFs to reset mocks between tests.
+
+import { Stats } from 'fs';
+
+// Mock fs/promises functions
+export const mockFsAccess = jest.fn();
+export const mockFsStat = jest.fn();
+export const mockFsReadFile = jest.fn();
+export const mockFsReaddir = jest.fn();
+export const mockFsWriteFile = jest.fn();
+
+// Mock the entire fs/promises module. This must be in the same file as the mocks it uses.
+jest.mock('fs/promises', () => ({
+  __esModule: true,
+  access: mockFsAccess,
+  stat: mockFsStat,
+  readFile: mockFsReadFile,
+  readdir: mockFsReaddir,
+  writeFile: mockFsWriteFile,
+}));
+
+/**
+ * Sets up the mock file system for tests.
+ * @param files A map where keys are file/dir paths and values describe their properties.
+ * @param content A map of file paths to their content.
+ */
+export const setupMockFs = (
+  files: Map<string, { isDirectory: boolean; files?: string[] }>,
+  content: Map<string, string> = new Map()
+) => {
+  mockFsAccess.mockImplementation(async (filePath) => {
+    const pathStr = filePath.toString().replace(/\\/g, '/');
+    if (!files.has(pathStr)) {
+      const error = new Error(
+        `ENOENT: no such file or directory, access '${pathStr}'`
+      );
+      (error as NodeJS.ErrnoException).code = 'ENOENT';
+      throw error;
+    }
+  });
+
+  mockFsStat.mockImplementation(async (filePath) => {
+    const pathStr = filePath.toString().replace(/\\/g, '/');
+    const entry = files.get(pathStr);
+    if (!entry) {
+      const error = new Error(
+        `ENOENT: no such file or directory, stat '${pathStr}'`
+      );
+      (error as NodeJS.ErrnoException).code = 'ENOENT';
+      throw error;
+    }
+    return { isDirectory: () => entry.isDirectory } as Stats;
+  });
+
+  mockFsReaddir.mockImplementation(async (dirPath) => {
+    const pathStr = dirPath.toString().replace(/\\/g, '/');
+    const entry = files.get(pathStr);
+    if (!entry || !entry.isDirectory) {
+      const error = new Error(`ENOTDIR: not a directory, scandir '${pathStr}'`);
+      (error as NodeJS.ErrnoException).code = 'ENOTDIR';
+      throw error;
+    }
+    return (entry.files ?? []) as any;
+  });
+
+  mockFsReadFile.mockImplementation(async (filePath) => {
+    const pathStr = filePath.toString().replace(/\\/g, '/');
+    const fileContent = content.get(pathStr);
+    if (fileContent !== undefined) {
+      return fileContent;
+    }
+    // If a file is in the `files` map but not `content`, it exists but is empty.
+    if (files.has(pathStr) && !files.get(pathStr)?.isDirectory) {
+      return '';
+    }
+    const error = new Error(
+      `ENOENT: no such file or directory, open '${pathStr}'`
+    );
+    (error as NodeJS.ErrnoException).code = 'ENOENT';
+    throw error;
+  });
+
+  // Default for writeFile
+  mockFsWriteFile.mockResolvedValue(undefined);
+};
+
+/**
+ * Clears all filesystem mocks.
+ */
+export const clearMockFs = () => {
+  jest.clearAllMocks();
+};

--- a/electron/ignoreRulesManager.test.ts
+++ b/electron/ignoreRulesManager.test.ts
@@ -574,6 +574,97 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         expect(ignoreRulesManager.ignores('temp.log')).toBe(true);
       });
     });
+
+    describe('Nested override scenarios', () => {
+      it('Test A: .athignore should un-ignore a file pattern ignored by a parent .gitignore', async () => {
+        const fileStructure = new Map([
+          [
+            '/test/project',
+            { isDirectory: true, files: ['.athignore', '.gitignore', 'legacy.bak', 'restore/', '.ath_materials'] },
+          ],
+          [
+            '/test/project/.ath_materials',
+            { isDirectory: true, files: ['project_settings.json'] },
+          ],
+          [
+            '/test/project/restore',
+            { isDirectory: true, files: ['important.bak'] },
+          ],
+        ]);
+        const ignoreFiles = new Map([
+          ['/test/project/.ath_materials/project_settings.json', '{}'],
+          ['/test/project/.gitignore', '*.bak'], // Ignore all .bak files
+          ['/test/project/.athignore', '!restore/important.bak'], // But not this one
+        ]);
+        setupMockFs(fileStructure, ignoreFiles);
+        await ignoreRulesManager.loadIgnoreRules();
+        
+        expect(ignoreRulesManager.ignores('legacy.bak')).toBe(true);
+        expect(ignoreRulesManager.ignores('restore/important.bak')).toBe(false);
+      });
+
+      it('Test B: .athignore ignore should not be undone by a nested .gitignore un-ignore', async () => {
+        const fileStructure = new Map([
+          [
+            '/test/project',
+            { isDirectory: true, files: ['.athignore', 'dist/', '.ath_materials'] },
+          ],
+          [
+            '/test/project/.ath_materials',
+            { isDirectory: true, files: ['project_settings.json'] },
+          ],
+          [
+            '/test/project/dist',
+            { isDirectory: true, files: ['.gitignore', 'somefile', 'keep.me'] },
+          ],
+        ]);
+        const ignoreFiles = new Map([
+          ['/test/project/.ath_materials/project_settings.json', '{}'],
+          ['/test/project/.athignore', 'dist/*'], // Ignore contents of dist
+          ['/test/project/dist/.gitignore', '!keep.me'], // Attempt to un-ignore
+        ]);
+        setupMockFs(fileStructure, ignoreFiles);
+        await ignoreRulesManager.loadIgnoreRules();
+        
+        // The .athignore rule takes precedence, so the un-ignore in .gitignore has no effect.
+        expect(ignoreRulesManager.ignores('dist/somefile')).toBe(true);
+        expect(ignoreRulesManager.ignores('dist/keep.me')).toBe(true);
+      });
+      
+      it('Test C: .athignore un-ignore should trump a deeper .gitignore re-ignore', async () => {
+        const fileStructure = new Map([
+          [
+            '/test/project',
+            { isDirectory: true, files: ['.gitignore', 'app.log', 'src/', '.ath_materials'] },
+          ],
+          [
+            '/test/project/.ath_materials',
+            { isDirectory: true, files: ['project_settings.json'] },
+          ],
+          [
+            '/test/project/src',
+            { isDirectory: true, files: ['.athignore', 'important.log', 'feature/'] },
+          ],
+          [
+            '/test/project/src/feature',
+            { isDirectory: true, files: ['.gitignore', 'important.log'] },
+          ],
+        ]);
+        const ignoreFiles = new Map([
+          ['/test/project/.ath_materials/project_settings.json', '{}'],
+          ['/test/project/.gitignore', '*.log'], // Globally ignore logs
+          ['/test/project/src/.athignore', '!important.log'], // Un-ignore this name inside src/
+          ['/test/project/src/feature/.gitignore', 'important.log'], // Try to re-ignore it
+        ]);
+        setupMockFs(fileStructure, ignoreFiles);
+        await ignoreRulesManager.loadIgnoreRules();
+
+        expect(ignoreRulesManager.ignores('app.log')).toBe(true);
+        expect(ignoreRulesManager.ignores('src/important.log')).toBe(false);
+        // The .athignore un-ignore takes precedence over the deeper .gitignore re-ignore
+        expect(ignoreRulesManager.ignores('src/feature/important.log')).toBe(false);
+      });
+    });
   });
 
   describe('addIgnorePattern', () => {

--- a/electron/ignoreRulesManager.test.ts
+++ b/electron/ignoreRulesManager.test.ts
@@ -1,22 +1,17 @@
 // AI Summary: Comprehensive unit tests for the intelligent ignore file scanner covering nested discovery,
 // ignore rule application for pruning, sorting by depth, and integration with project settings.
 
-// Mocks are defined before imports to prevent temporal dead zone errors due to jest.mock hoisting.
-const mockFsAccess = jest.fn();
-const mockFsStat = jest.fn();
-const mockFsReadFile = jest.fn();
-const mockFsReaddir = jest.fn();
-const mockFsWriteFile = jest.fn();
+// Import mock helpers first to ensure mocks are established.
+import {
+  setupMockFs,
+  clearMockFs,
+  mockFsAccess,
+  mockFsReadFile,
+  mockFsWriteFile,
+  mockFsReaddir,
+} from './__tests__/mockFsHelpers';
 
-jest.mock('fs/promises', () => ({
-  __esModule: true,
-  access: mockFsAccess,
-  stat: mockFsStat,
-  readFile: mockFsReadFile,
-  readdir: mockFsReaddir,
-  writeFile: mockFsWriteFile,
-}));
-
+// PathUtils is mocked here because it's a direct dependency of ignoreRulesManager
 jest.mock('./services/PathUtils', () => ({
   __esModule: true,
   PathUtils: {
@@ -82,10 +77,10 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
     console.log = originalConsoleLog;
     console.error = originalConsoleError;
     console.warn = originalConsoleWarn;
-   });
+  });
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    clearMockFs();
 
     // Clear error state to prevent test leakage
     ignoreRulesManager.clearError();
@@ -145,33 +140,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         ['/test/project/src/components/.gitignore', '*.stories.ts'],
       ]);
 
-      // Mock fs operations
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsStat.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const entry = fileStructure.get(pathStr);
-        return {
-          isDirectory: () => entry?.isDirectory ?? false,
-        } as Stats;
-      });
-
-      mockFsReaddir.mockImplementation(async (dirPath) => {
-        const pathStr = dirPath.toString();
-        const entry = fileStructure.get(pathStr);
-        return (entry?.files ?? []) as any;
-      });
-
-      mockFsReadFile.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const content = ignoreFiles.get(pathStr);
-        if (content !== undefined) {
-          return content;
-        }
-        // If a file is not in the map, simulate a "file not found" error.
-        const error = new Error(`ENOENT: no such file or directory, open '${pathStr}'`);
-        (error as NodeJS.ErrnoException).code = 'ENOENT';
-        throw error;
-      });
+      setupMockFs(fileStructure, ignoreFiles);
 
       // Load ignore rules to trigger scanning
       await ignoreRulesManager.loadIgnoreRules();
@@ -225,32 +194,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         ['/test/project/.gitignore', 'node_modules/'],
       ]);
 
-      // Mock fs operations
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsStat.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const entry = fileStructure.get(pathStr);
-        return {
-          isDirectory: () => entry?.isDirectory ?? false,
-        } as Stats;
-      });
-
-      mockFsReaddir.mockImplementation(async (dirPath) => {
-        const pathStr = dirPath.toString();
-        const entry = fileStructure.get(pathStr);
-        return (entry?.files ?? []) as any;
-      });
-
-      mockFsReadFile.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const content = ignoreFiles.get(pathStr);
-        if (content !== undefined) {
-          return content;
-        }
-        const error = new Error(`ENOENT: no such file or directory, open '${pathStr}'`);
-        (error as NodeJS.ErrnoException).code = 'ENOENT';
-        throw error;
-      });
+      setupMockFs(fileStructure, ignoreFiles);
 
       // Load ignore rules to trigger scanning
       await ignoreRulesManager.loadIgnoreRules();
@@ -279,27 +223,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         ],
       ]);
 
-      // Mock fs operations
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsStat.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const entry = fileStructure.get(pathStr);
-        return {
-          isDirectory: () => entry?.isDirectory ?? false,
-        } as Stats;
-      });
-
-      mockFsReaddir.mockImplementation(async (dirPath) => {
-        const pathStr = dirPath.toString();
-        const entry = fileStructure.get(pathStr);
-        return (entry?.files ?? []) as any;
-      });
-
-      mockFsReadFile.mockImplementation(async (filePath) => {
-        const error = new Error(`ENOENT for read ${filePath}`);
-        (error as NodeJS.ErrnoException).code = 'ENOENT';
-        throw error;
-      });
+      setupMockFs(fileStructure);
 
       // Should not throw when no ignore files exist
       await expect(ignoreRulesManager.loadIgnoreRules()).resolves.not.toThrow();
@@ -327,32 +251,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         ],
       ]);
 
-      // Mock fs operations
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsStat.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const entry = fileStructure.get(pathStr);
-        return {
-          isDirectory: () => entry?.isDirectory ?? false,
-        } as Stats;
-      });
-
-      mockFsReaddir.mockImplementation(async (dirPath) => {
-        const pathStr = dirPath.toString();
-        const entry = fileStructure.get(pathStr);
-        return (entry?.files ?? []) as any;
-      });
-
-      mockFsReadFile.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const content = ignoreFiles.get(pathStr);
-        if (content) {
-          return content;
-        }
-        const error = new Error(`ENOENT for read ${filePath}`);
-        (error as NodeJS.ErrnoException).code = 'ENOENT';
-        throw error;
-      });
+      setupMockFs(fileStructure, ignoreFiles);
 
       // Load ignore rules to trigger scanning
       await ignoreRulesManager.loadIgnoreRules();
@@ -381,34 +280,11 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
           { isDirectory: true, files: ['project_settings.json', '.gitignore'] },
         ],
       ]);
+      const content = new Map([
+        ['/test/project/.ath_materials/project_settings.json', '{}'],
+      ]);
 
-      // Mock fs operations
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsStat.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const entry = fileStructure.get(pathStr);
-        return {
-          isDirectory: () => entry?.isDirectory ?? false,
-        } as Stats;
-      });
-
-      mockFsReaddir.mockImplementation(async (dirPath) => {
-        const pathStr = dirPath.toString();
-        const entry = fileStructure.get(pathStr);
-        return (entry?.files ?? []) as any;
-      });
-
-      mockFsReadFile.mockImplementation(async (filePath) => {
-        // Only project_settings.json should be read
-        if (
-          filePath === '/test/project/.ath_materials/project_settings.json'
-        ) {
-          return '{}';
-        }
-        const error = new Error(`ENOENT for read ${filePath}`);
-        (error as NodeJS.ErrnoException).code = 'ENOENT';
-        throw error;
-      });
+      setupMockFs(fileStructure, content);
 
       // Load ignore rules to trigger scanning
       await ignoreRulesManager.loadIgnoreRules();
@@ -433,31 +309,16 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         ['/test/project/restricted', { isDirectory: true, files: [] }],
       ]);
 
-      // Mock fs operations
-      mockFsAccess.mockResolvedValue(undefined); // Allow access check to pass
-
-      mockFsStat.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const entry = fileStructure.get(pathStr);
-        return {
-          isDirectory: () => entry?.isDirectory ?? false,
-        } as Stats;
-      });
-
+      setupMockFs(fileStructure);
+      
+      // Fail readdir for the 'restricted' directory to trigger the console.warn
       mockFsReaddir.mockImplementation(async (dirPath) => {
         const pathStr = dirPath.toString();
-        // Fail readdir for the 'restricted' directory to trigger the console.warn
         if (pathStr === '/test/project/restricted') {
           throw new Error('Permission denied on readdir');
         }
         const entry = fileStructure.get(pathStr);
         return (entry?.files ?? []) as any;
-      });
-
-      mockFsReadFile.mockImplementation(async (filePath) => {
-        const error = new Error(`ENOENT for read ${filePath}`);
-        (error as NodeJS.ErrnoException).code = 'ENOENT';
-        throw error;
       });
 
       // Should not throw when encountering inaccessible directories
@@ -486,32 +347,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         ['/test/project/.ath_materials/project_settings.json', 'invalid json{'],
       ]);
 
-      // Mock fs operations
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsStat.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const entry = fileStructure.get(pathStr);
-        return {
-          isDirectory: () => entry?.isDirectory ?? false,
-        } as Stats;
-      });
-
-      mockFsReaddir.mockImplementation(async (dirPath) => {
-        const pathStr = dirPath.toString();
-        const entry = fileStructure.get(pathStr);
-        return (entry?.files ?? []) as any;
-      });
-
-      mockFsReadFile.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const content = ignoreFiles.get(pathStr);
-        if (content) {
-          return content;
-        }
-        const error = new Error(`ENOENT for read ${filePath}`);
-        (error as NodeJS.ErrnoException).code = 'ENOENT';
-        throw error;
-      });
+      setupMockFs(fileStructure, ignoreFiles);
 
       await ignoreRulesManager.loadIgnoreRules();
 
@@ -540,31 +376,6 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
       loadIgnoreRulesSpy.mockRestore();
     });
 
-    const setupFS = (
-      files: Map<string, { isDirectory: boolean; files?: string[] }>,
-      ignoreContent: Map<string, string>
-    ) => {
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsStat.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const entry = files.get(pathStr);
-        if (!entry) throw new Error('ENOENT for stat');
-        return { isDirectory: () => entry.isDirectory } as Stats;
-      });
-      mockFsReaddir.mockImplementation(async (dirPath) => {
-        const pathStr = dirPath.toString();
-        return (files.get(pathStr)?.files ?? []) as any;
-      });
-      mockFsReadFile.mockImplementation(async (filePath) => {
-        const pathStr = filePath.toString();
-        const content = ignoreContent.get(pathStr);
-        if (content !== undefined) return content;
-        const error = new Error(`ENOENT for read`);
-        (error as NodeJS.ErrnoException).code = 'ENOENT';
-        throw error;
-      });
-    };
-
     describe('Hierarchical Logic - Parent/Child Overrides', () => {
       it('should handle parent ignores, child un-ignores', async () => {
         const fileStructure = new Map([
@@ -586,7 +397,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
           ['/test/project/.gitignore', '*.log'],
           ['/test/project/src/.gitignore', '!important.log'],
         ]);
-        setupFS(fileStructure, ignoreFiles);
+        setupMockFs(fileStructure, ignoreFiles);
         await ignoreRulesManager.loadIgnoreRules();
 
         expect(ignoreRulesManager.ignores('src/important.log')).toBe(false);
@@ -637,7 +448,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
           ['/test/project/docs/.gitignore', 'guide.md'], // Ignore guide.md only within docs
         ]);
 
-        setupFS(fileStructure, ignoreFiles);
+        setupMockFs(fileStructure, ignoreFiles);
         await ignoreRulesManager.loadIgnoreRules();
 
         // Test scoping of src/.gitignore
@@ -692,7 +503,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
           ['/test/project/src/.gitignore', 'build/\n/output\n!/config.js'],
         ]);
 
-        setupFS(fileStructure, ignoreFiles);
+        setupMockFs(fileStructure, ignoreFiles);
         await ignoreRulesManager.loadIgnoreRules();
 
         // 1. Pattern with a trailing slash: `build/` in `src/`. Should ignore `src/build/`.
@@ -724,7 +535,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
           ['/test/project/.gitignore', 'config.json'],
           ['/test/project/.athignore', '!config.json'],
         ]);
-        setupFS(fileStructure, ignoreFiles);
+        setupMockFs(fileStructure, ignoreFiles);
         await ignoreRulesManager.loadIgnoreRules();
         
         expect(ignoreRulesManager.ignores('config.json')).toBe(false);
@@ -740,7 +551,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
           ['/test/project/.gitignore', '!config.json'],
           ['/test/project/.athignore', 'config.json'],
         ]);
-        setupFS(fileStructure, ignoreFiles);
+        setupMockFs(fileStructure, ignoreFiles);
         await ignoreRulesManager.loadIgnoreRules();
         
         expect(ignoreRulesManager.ignores('config.json')).toBe(true);
@@ -756,7 +567,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
           ['/test/project/.gitignore', '*.bak'],
           ['/test/project/.athignore', '*.log'], // No opinion on .bak files
         ]);
-        setupFS(fileStructure, ignoreFiles);
+        setupMockFs(fileStructure, ignoreFiles);
         await ignoreRulesManager.loadIgnoreRules();
         
         expect(ignoreRulesManager.ignores('temp.bak')).toBe(true);
@@ -767,8 +578,8 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
 
   describe('addIgnorePattern', () => {
     beforeEach(() => {
-      // Restore the real addIgnorePattern method for these tests
-      jest.restoreAllMocks();
+      // Restore mocks and spies
+      clearMockFs();
 
       // Mock file operations for addIgnorePattern
       mockFsAccess.mockResolvedValue(undefined);
@@ -823,12 +634,12 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
 
     it('should create .athignore file if it does not exist', async () => {
       mockFsAccess.mockRejectedValue(new Error('File not found'));
-      mockFsReadFile.mockResolvedValue('');
-      mockFsWriteFile.mockResolvedValue(undefined);
-
+      mockFsReadFile.mockResolvedValue(''); // read returns empty for the new file
+      
       const result = await ignoreRulesManager.addIgnorePattern('*.log');
 
       expect(result).toBe(true);
+      // It tries to access, fails, then writes an empty file, then reads it, then writes content
       expect(mockFsWriteFile).toHaveBeenCalledWith(
         '/test/project/.athignore',
         '',

--- a/electron/ignoreRulesManager.test.ts
+++ b/electron/ignoreRulesManager.test.ts
@@ -21,16 +21,14 @@ jest.mock('./services/PathUtils', () => ({
     relative: jest.fn((from: string, to: string) =>
       path.posix.relative(from, to)
     ),
-    normalizeForIgnore: jest.fn(
-      (filePath: string, isDirectory: boolean) => {
-        if (!filePath) return null;
-        let norm = filePath.replace(/\\/g, '/');
-        if (isDirectory && !norm.endsWith('/')) {
-          norm += '/';
-        }
-        return norm;
+    normalizeForIgnore: jest.fn((filePath: string, isDirectory: boolean) => {
+      if (!filePath) return null;
+      let norm = filePath.replace(/\\/g, '/');
+      if (isDirectory && !norm.endsWith('/')) {
+        norm += '/';
       }
-    ),
+      return norm;
+    }),
     getAncestors: jest.fn((filePath) => {
       if (!filePath || filePath === '.') return ['.'];
       const normalized = filePath.replace(/\\/g, '/').replace(/\/$/, '');
@@ -61,6 +59,12 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
   let originalConsoleError: typeof console.error;
   let originalConsoleWarn: typeof console.warn;
   let loadIgnoreRulesSpy: jest.SpyInstance;
+
+  // IMPORTANT: When defining mock file structures, NEVER include trailing slashes 
+  // in directory names within the 'files' arrays. Real Node.js fs.readdir() returns 
+  // directory names WITHOUT trailing slashes (e.g., 'src', not 'src/'). 
+  // Including trailing slashes will cause the mock fs operations to fail silently 
+  // and prevent the scanner from recursing into directories, leading to test failures.
 
   beforeAll(() => {
     // Mock console to prevent logging during tests
@@ -214,7 +218,10 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
     it('should handle missing ignore files gracefully', async () => {
       // Setup file system structure without ignore files
       const fileStructure = new Map([
-        ['/test/project', { isDirectory: true, files: ['src', '.ath_materials'] }],
+        [
+          '/test/project',
+          { isDirectory: true, files: ['src', '.ath_materials'] },
+        ],
         ['/test/project/.ath_materials', { isDirectory: true, files: [] }],
         ['/test/project/src', { isDirectory: true, files: ['components'] }],
         [
@@ -310,7 +317,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
       ]);
 
       setupMockFs(fileStructure);
-      
+
       // Fail readdir for the 'restricted' directory to trigger the console.warn
       mockFsReaddir.mockImplementation(async (dirPath) => {
         const pathStr = dirPath.toString();
@@ -352,8 +359,10 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
       await ignoreRulesManager.loadIgnoreRules();
 
       // Should not throw, should log a warning, and should proceed with defaults
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Could not read or parse project_settings.json'));
-      
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Could not read or parse project_settings.json')
+      );
+
       // Should have attempted to read project settings
       expect(mockFsReadFile).toHaveBeenCalledWith(
         '/test/project/.ath_materials/project_settings.json',
@@ -364,7 +373,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         '/test/project/.gitignore',
         'utf-8'
       );
-      
+
       // Verify the rule from .gitignore was actually loaded
       expect(ignoreRulesManager.ignores('dist/')).toBe(true);
     });
@@ -381,7 +390,10 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         const fileStructure = new Map([
           [
             '/test/project',
-            { isDirectory: true, files: ['.gitignore', 'src', '.ath_materials'] },
+            {
+              isDirectory: true,
+              files: ['.gitignore', 'src', '.ath_materials'],
+            },
           ],
           [
             '/test/project/.ath_materials',
@@ -429,16 +441,16 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
             '/test/project/src',
             {
               isDirectory: true,
-              files: ['.gitignore', 'component.log', 'component.tmp', 'sub/'],
+              files: ['.gitignore', 'component.log', 'component.tmp', 'sub'],
             },
           ],
-          [
-            '/test/project/src/sub',
-            { isDirectory: true, files: ['deep.log'] },
-          ],
+          ['/test/project/src/sub', { isDirectory: true, files: ['deep.log'] }],
           [
             '/test/project/docs',
-            { isDirectory: true, files: ['.gitignore', 'guide.md', 'guide.log'] },
+            {
+              isDirectory: true,
+              files: ['.gitignore', 'guide.md', 'guide.log'],
+            },
           ],
         ]);
         const ignoreFiles = new Map([
@@ -483,13 +495,10 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
             '/test/project/src',
             {
               isDirectory: true,
-              files: ['.gitignore', 'build/', 'output', 'config.js', 'lib/'],
+              files: ['.gitignore', 'build', 'output', 'config.js', 'lib'],
             },
           ],
-          [
-            '/test/project/src/build',
-            { isDirectory: true, files: ['app.js'] },
-          ],
+          ['/test/project/src/build', { isDirectory: true, files: ['app.js'] }],
           [
             '/test/project/src/lib',
             { isDirectory: true, files: ['config.js', 'other.js'] },
@@ -527,8 +536,22 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
     describe('Athanor-First Precedence', () => {
       it('should prioritize .athignore un-ignore over .gitignore ignore', async () => {
         const fileStructure = new Map([
-          ['/test/project', { isDirectory: true, files: ['.athignore', '.gitignore', 'config.json', '.ath_materials'] }],
-          ['/test/project/.ath_materials', { isDirectory: true, files: ['project_settings.json'] }],
+          [
+            '/test/project',
+            {
+              isDirectory: true,
+              files: [
+                '.athignore',
+                '.gitignore',
+                'config.json',
+                '.ath_materials',
+              ],
+            },
+          ],
+          [
+            '/test/project/.ath_materials',
+            { isDirectory: true, files: ['project_settings.json'] },
+          ],
         ]);
         const ignoreFiles = new Map([
           ['/test/project/.ath_materials/project_settings.json', '{}'],
@@ -537,14 +560,28 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         ]);
         setupMockFs(fileStructure, ignoreFiles);
         await ignoreRulesManager.loadIgnoreRules();
-        
+
         expect(ignoreRulesManager.ignores('config.json')).toBe(false);
       });
 
       it('should prioritize .athignore ignore over .gitignore un-ignore', async () => {
         const fileStructure = new Map([
-          ['/test/project', { isDirectory: true, files: ['.athignore', '.gitignore', 'config.json', '.ath_materials'] }],
-          ['/test/project/.ath_materials', { isDirectory: true, files: ['project_settings.json'] }],
+          [
+            '/test/project',
+            {
+              isDirectory: true,
+              files: [
+                '.athignore',
+                '.gitignore',
+                'config.json',
+                '.ath_materials',
+              ],
+            },
+          ],
+          [
+            '/test/project/.ath_materials',
+            { isDirectory: true, files: ['project_settings.json'] },
+          ],
         ]);
         const ignoreFiles = new Map([
           ['/test/project/.ath_materials/project_settings.json', '{}'],
@@ -553,14 +590,23 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         ]);
         setupMockFs(fileStructure, ignoreFiles);
         await ignoreRulesManager.loadIgnoreRules();
-        
+
         expect(ignoreRulesManager.ignores('config.json')).toBe(true);
       });
 
       it('should fall back to .gitignore when .athignore has no opinion', async () => {
         const fileStructure = new Map([
-          ['/test/project', { isDirectory: true, files: ['.athignore', '.gitignore', 'temp.bak', '.ath_materials'] }],
-          ['/test/project/.ath_materials', { isDirectory: true, files: ['project_settings.json'] }],
+          [
+            '/test/project',
+            {
+              isDirectory: true,
+              files: ['.athignore', '.gitignore', 'temp.bak', '.ath_materials'],
+            },
+          ],
+          [
+            '/test/project/.ath_materials',
+            { isDirectory: true, files: ['project_settings.json'] },
+          ],
         ]);
         const ignoreFiles = new Map([
           ['/test/project/.ath_materials/project_settings.json', '{}'],
@@ -569,7 +615,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         ]);
         setupMockFs(fileStructure, ignoreFiles);
         await ignoreRulesManager.loadIgnoreRules();
-        
+
         expect(ignoreRulesManager.ignores('temp.bak')).toBe(true);
         expect(ignoreRulesManager.ignores('temp.log')).toBe(true);
       });
@@ -580,7 +626,16 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         const fileStructure = new Map([
           [
             '/test/project',
-            { isDirectory: true, files: ['.athignore', '.gitignore', 'legacy.bak', 'restore/', '.ath_materials'] },
+            {
+              isDirectory: true,
+              files: [
+                '.athignore',
+                '.gitignore',
+                'legacy.bak',
+                'restore',
+                '.ath_materials',
+              ],
+            },
           ],
           [
             '/test/project/.ath_materials',
@@ -598,7 +653,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         ]);
         setupMockFs(fileStructure, ignoreFiles);
         await ignoreRulesManager.loadIgnoreRules();
-        
+
         expect(ignoreRulesManager.ignores('legacy.bak')).toBe(true);
         expect(ignoreRulesManager.ignores('restore/important.bak')).toBe(false);
       });
@@ -607,7 +662,10 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         const fileStructure = new Map([
           [
             '/test/project',
-            { isDirectory: true, files: ['.athignore', 'dist/', '.ath_materials'] },
+            {
+              isDirectory: true,
+              files: ['.athignore', 'dist', '.ath_materials'],
+            },
           ],
           [
             '/test/project/.ath_materials',
@@ -625,17 +683,23 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         ]);
         setupMockFs(fileStructure, ignoreFiles);
         await ignoreRulesManager.loadIgnoreRules();
-        
+
         // The .athignore rule takes precedence, so the un-ignore in .gitignore has no effect.
         expect(ignoreRulesManager.ignores('dist/somefile')).toBe(true);
         expect(ignoreRulesManager.ignores('dist/keep.me')).toBe(true);
       });
-      
-      it('Test C: .athignore un-ignore should trump a deeper .gitignore re-ignore', async () => {
+
+      // We are building towards 'Test C: .athignore un-ignore should trump a
+      // deeper .gitignore re-ignore' - we use the same file/folder structure
+      // but change the location of ignore files.
+      it('Test C-Root-1: All rules at root level, only .gitignore', async () => {
         const fileStructure = new Map([
           [
             '/test/project',
-            { isDirectory: true, files: ['.gitignore', 'app.log', 'src/', '.ath_materials'] },
+            {
+              isDirectory: true,
+              files: ['.gitignore', 'app.log', 'src', '.ath_materials'],
+            },
           ],
           [
             '/test/project/.ath_materials',
@@ -643,7 +707,212 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
           ],
           [
             '/test/project/src',
-            { isDirectory: true, files: ['.athignore', 'important.log', 'feature/'] },
+            { isDirectory: true, files: ['important.log', 'feature'] },
+          ],
+          [
+            '/test/project/src/feature',
+            { isDirectory: true, files: ['important.log'] },
+          ],
+        ]);
+        const ignoreFiles = new Map([
+          ['/test/project/.ath_materials/project_settings.json', '{}'],
+          ['/test/project/.gitignore', '*.log\n!src/important.log'], // Globally ignore logs, but un-ignore src/important.log
+        ]);
+        setupMockFs(fileStructure, ignoreFiles);
+        await ignoreRulesManager.loadIgnoreRules();
+
+        expect(ignoreRulesManager.ignores('app.log')).toBe(true);
+        expect(ignoreRulesManager.ignores('src/important.log')).toBe(false);
+        expect(ignoreRulesManager.ignores('src/feature/important.log')).toBe(
+          true
+        );
+      });
+
+      it('Test C-Root-2: All rules at root level, .athignore overrides .gitignore (first case)', async () => {
+        const fileStructure = new Map([
+          [
+            '/test/project',
+            {
+              isDirectory: true,
+              files: [
+                '.gitignore',
+                '.athignore',
+                'app.log',
+                'src',
+                '.ath_materials',
+              ],
+            },
+          ],
+          [
+            '/test/project/.ath_materials',
+            { isDirectory: true, files: ['project_settings.json'] },
+          ],
+          [
+            '/test/project/src',
+            { isDirectory: true, files: ['important.log', 'feature'] },
+          ],
+          [
+            '/test/project/src/feature',
+            { isDirectory: true, files: ['important.log'] },
+          ],
+        ]);
+        const ignoreFiles = new Map([
+          ['/test/project/.ath_materials/project_settings.json', '{}'],
+          ['/test/project/.gitignore', '*.log'], // Globally ignore logs
+          ['/test/project/.athignore', '!src/important.log'], // Athignore un-ignores src/important.log (should have precedence)
+        ]);
+        setupMockFs(fileStructure, ignoreFiles);
+        await ignoreRulesManager.loadIgnoreRules();
+
+        expect(ignoreRulesManager.ignores('app.log')).toBe(true);
+        expect(ignoreRulesManager.ignores('src/important.log')).toBe(false);
+        expect(ignoreRulesManager.ignores('src/feature/important.log')).toBe(
+          true
+        );
+      });
+
+      it('Test C-Root-3: All rules at root level, .athignore overrides .gitignore (second case)', async () => {
+        const fileStructure = new Map([
+          [
+            '/test/project',
+            {
+              isDirectory: true,
+              files: [
+                '.gitignore',
+                '.athignore',
+                'app.log',
+                'src',
+                '.ath_materials',
+              ],
+            },
+          ],
+          [
+            '/test/project/.ath_materials',
+            { isDirectory: true, files: ['project_settings.json'] },
+          ],
+          [
+            '/test/project/src',
+            { isDirectory: true, files: ['important.log', 'feature'] },
+          ],
+          [
+            '/test/project/src/feature',
+            { isDirectory: true, files: ['important.log'] },
+          ],
+        ]);
+        const ignoreFiles = new Map([
+          ['/test/project/.ath_materials/project_settings.json', '{}'],
+          ['/test/project/.athignore', '*.log'], // Globally ignore logs
+          ['/test/project/.gitignore', '!src/important.log'], // Athignore has precedence so this should do nothing
+        ]);
+        setupMockFs(fileStructure, ignoreFiles);
+        await ignoreRulesManager.loadIgnoreRules();
+
+        expect(ignoreRulesManager.ignores('app.log')).toBe(true);
+        expect(ignoreRulesManager.ignores('src/important.log')).toBe(true);
+        expect(ignoreRulesManager.ignores('src/feature/important.log')).toBe(
+          true
+        );
+      });
+
+      it('Test C-Root-4: All rules at root level, .athignore overrides .gitignore (third case with glob pattern)', async () => {
+        const fileStructure = new Map([
+          [
+            '/test/project',
+            {
+              isDirectory: true,
+              files: [
+                '.gitignore',
+                '.athignore',
+                'app.log',
+                'src',
+                '.ath_materials',
+              ],
+            },
+          ],
+          [
+            '/test/project/.ath_materials',
+            { isDirectory: true, files: ['project_settings.json'] },
+          ],
+          [
+            '/test/project/src',
+            { isDirectory: true, files: ['important.log', 'feature'] },
+          ],
+          [
+            '/test/project/src/feature',
+            { isDirectory: true, files: ['important.log'] },
+          ],
+        ]);
+        const ignoreFiles = new Map([
+          ['/test/project/.ath_materials/project_settings.json', '{}'],
+          ['/test/project/.gitignore', '*.log'], // Globally ignore logs
+          ['/test/project/.athignore', '!src/**/important.log'], // Athignore un-ignores all importance.log files in src/
+        ]);
+        setupMockFs(fileStructure, ignoreFiles);
+        await ignoreRulesManager.loadIgnoreRules();
+
+        expect(ignoreRulesManager.ignores('app.log')).toBe(true);
+        expect(ignoreRulesManager.ignores('src/important.log')).toBe(false);
+        expect(ignoreRulesManager.ignores('src/feature/important.log')).toBe(
+          false
+        );
+      });
+
+      it('Test C1: .athignore un-ignore should trump a shallower .gitignore', async () => {
+        const fileStructure = new Map([
+          [
+            '/test/project',
+            {
+              isDirectory: true,
+              files: ['.gitignore', 'app.log', 'src', '.ath_materials'],
+            },
+          ],
+          [
+            '/test/project/.ath_materials',
+            { isDirectory: true, files: ['project_settings.json'] },
+          ],
+          [
+            '/test/project/src',
+            {
+              isDirectory: true,
+              files: ['.athignore', 'important.log', 'feature'],
+            },
+          ],
+          [
+            '/test/project/src/feature',
+            { isDirectory: true, files: ['important.log'] },
+          ],
+        ]);
+        const ignoreFiles = new Map([
+          ['/test/project/.ath_materials/project_settings.json', '{}'],
+          ['/test/project/.gitignore', '*.log'], // Globally ignore logs
+          ['/test/project/src/.athignore', '!important.log'], // Un-ignore this name inside src/
+        ]);
+        setupMockFs(fileStructure, ignoreFiles);
+        await ignoreRulesManager.loadIgnoreRules();
+
+        expect(ignoreRulesManager.ignores('app.log')).toBe(true);
+        expect(ignoreRulesManager.ignores('src/important.log')).toBe(false);
+      });
+
+      it('Test C2: .athignore un-ignore should trump both a shallower .gitignore and a deeper .gitignore re-ignore', async () => {
+        const fileStructure = new Map([
+          [
+            '/test/project',
+            {
+              isDirectory: true,
+              files: ['.gitignore', 'app.log', 'src', '.ath_materials'],
+            },
+          ],
+          [
+            '/test/project/.ath_materials',
+            { isDirectory: true, files: ['project_settings.json'] },
+          ],
+          [
+            '/test/project/src',
+            {
+              isDirectory: true,
+              files: ['.athignore', 'important.log', 'feature'],
+            },
           ],
           [
             '/test/project/src/feature',
@@ -662,7 +931,9 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
         expect(ignoreRulesManager.ignores('app.log')).toBe(true);
         expect(ignoreRulesManager.ignores('src/important.log')).toBe(false);
         // The .athignore un-ignore takes precedence over the deeper .gitignore re-ignore
-        expect(ignoreRulesManager.ignores('src/feature/important.log')).toBe(false);
+        expect(ignoreRulesManager.ignores('src/feature/important.log')).toBe(
+          false
+        );
       });
     });
   });
@@ -726,7 +997,7 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
     it('should create .athignore file if it does not exist', async () => {
       mockFsAccess.mockRejectedValue(new Error('File not found'));
       mockFsReadFile.mockResolvedValue(''); // read returns empty for the new file
-      
+
       const result = await ignoreRulesManager.addIgnorePattern('*.log');
 
       expect(result).toBe(true);
@@ -746,9 +1017,9 @@ describe('IgnoreRulesManager - Intelligent Scanner', () => {
     it('should handle errors gracefully', async () => {
       mockFsReadFile.mockRejectedValue(new Error('Permission denied'));
 
-      await expect(
-        ignoreRulesManager.addIgnorePattern('*.log')
-      ).resolves.toBe(false); // addIgnorePattern now returns false on error
+      await expect(ignoreRulesManager.addIgnorePattern('*.log')).resolves.toBe(
+        false
+      ); // addIgnorePattern now returns false on error
     });
   });
 

--- a/electron/ignoreRulesManager.ts
+++ b/electron/ignoreRulesManager.ts
@@ -326,16 +326,23 @@ class IgnoreRulesManager {
           finalPattern = finalPattern.substring(1);
         }
 
+        let transformed;
         if (finalPattern.startsWith('/')) {
-          // Pattern is already relative to the ignore file's directory root
-          finalPattern = finalPattern.substring(1);
+          // A leading slash anchors the pattern to the ignore file's directory.
+          // e.g., `/foo` in `src/.gitignore` becomes `src/foo`.
+          transformed = PathUtils.joinUnix(
+            directoryPath,
+            finalPattern.substring(1)
+          );
         } else if (!finalPattern.includes('/')) {
-          // Pattern does not contain a slash, so it should match anywhere in the subdirectory
-          finalPattern = `**/${finalPattern}`;
+          // A pattern without a slash matches in any subdirectory.
+          // e.g., `*.log` in `src/` becomes `src/**/*.log`.
+          transformed = PathUtils.joinUnix(directoryPath, '**', finalPattern);
+        } else {
+          // A pattern with a slash is relative to the ignore file's directory.
+          // e.g., `build/*.o` in `src/` becomes `src/build/*.o`.
+          transformed = PathUtils.joinUnix(directoryPath, finalPattern);
         }
-
-        // Join with the directory path to make it relative to the project root
-        let transformed = PathUtils.joinUnix(directoryPath, finalPattern);
 
         // Re-apply negation if it existed
         if (isNegated) {

--- a/electron/ignoreRulesManager.ts
+++ b/electron/ignoreRulesManager.ts
@@ -1,6 +1,6 @@
-// AI Summary: Manages nested ignore rules including intelligent discovery of all .athignore/.gitignore files,
-// rule application with "Athanor-First" precedence, and performance-optimized traversal that uses found rules
-// to prune directory scanning. Implements Git-like nested ignore behavior with comprehensive override capabilities.
+// AI Summary: Manages nested ignore rules by discovering all .athignore/.gitignore files and compiling them
+// into a single, unified ruleset. Enforces "Athanor-First" precedence by loading .gitignore rules before
+// .athignore rules. Uses found rules to prune directory scanning for performance.
 
 import * as path from 'path';
 import * as fs from 'fs/promises';
@@ -28,34 +28,33 @@ interface IgnoreFile {
 
 /**
  * IgnoreRulesManager implements a sophisticated "Deepest Opinion Wins" algorithm
- * for handling hierarchical ignore rules with Athanor's two-tier precedence system.
+ * for handling hierarchical ignore rules with Athanor's precedence system.
  *
- * ## Algorithm Overview: Pre-compiled Rulesets
+ * ## Algorithm Overview: Unified, Pre-compiled Ruleset
  *
- * To solve performance issues, this system uses a two-stage process. First, it discovers
- * all ignore files in the project. Second, it compiles their rules into master rulesets.
- * This makes checking if a file is ignored extremely fast.
+ * To solve performance issues and correctly handle precedence, this system uses a two-stage process.
+ * First, it discovers all ignore files in the project. Second, it compiles their rules into a
+ * **single, unified ruleset**. This makes checking if a file is ignored extremely fast and robust.
  *
- * ## Two-Tier Precedence System
+ * ## Precedence System: Athanor-First
  *
- * The algorithm operates in two distinct tiers, checked in order:
+ * The algorithm enforces "Athanor-First" precedence by controlling the order in which rules
+ * are added to the unified ruleset:
  *
- * **Tier 1: .athignore files (Primary)**
- * - These files have absolute highest precedence.
- * - If the master .athignore ruleset has an opinion, that decision is FINAL.
+ * 1.  **.gitignore files (Secondary)**: If enabled, all `.gitignore` rules are loaded first.
+ * 2.  **.athignore files (Primary)**: All `.athignore` rules are loaded **last**.
  *
- * **Tier 2: .gitignore files (Secondary)**
- * - Only consulted if Tier 1 had no opinion AND useGitignore setting is true.
+ * The `ignore` library's "last rule wins" behavior means that any rule from an `.athignore`
+ * file will correctly override a conflicting rule from a `.gitignore` file.
  *
  * ## Compilation and Override Logic
  *
- * - During `loadIgnoreRules()`, all found ignore files are sorted from shallowest to deepest.
- * - Their patterns are transformed to be root-relative and then added to the master `athIgnoreRules`
- * and `gitIgnoreRules` instances in that order. This correctly scopes rules to their
- * directory of origin while maintaining a centralized, performant ruleset.
- * - The `ignore` library ensures that later rules (from deeper files) correctly override earlier ones
- * from parent directories.
- * - This moves the computational complexity from check-time to a one-time load-time operation.
+ * - During `loadIgnoreRules()`, all found ignore files are sorted from shallowest to deepest
+ * within their respective type (`.gitignore` or `.athignore`).
+ * - Their patterns are transformed to be root-relative.
+ * - They are then added to the single `masterIgnoreRules` instance in the correct precedence order.
+ * - This moves the computational complexity from check-time to a one-time load-time operation and
+ * correctly implements all override logic.
  */
 class IgnoreRulesManager {
   private lastError: Error | null = null;
@@ -63,14 +62,9 @@ class IgnoreRulesManager {
   private baseDir = '';
   private lastLoadTime = 0;
 
-  // Master compiled rulesets
-  private athIgnoreRules: ignore.Ignore = ignore();
-  private gitIgnoreRules: ignore.Ignore = ignore();
+  // Master compiled ruleset
+  private masterIgnoreRules: ignore.Ignore = ignore();
   private useGitignore = SETTINGS.defaults.project.useGitignore;
-
-  // State tracking flags for debugging
-  private athRulesLoaded = false;
-  private gitRulesLoaded = false;
 
   // Update base directory and reload rules
   async setBaseDir(newDir: string) {
@@ -85,10 +79,7 @@ class IgnoreRulesManager {
 
   // Clear existing ignore rules
   clearRules() {
-    this.athIgnoreRules = ignore();
-    this.gitIgnoreRules = ignore();
-    this.athRulesLoaded = false;
-    this.gitRulesLoaded = false;
+    this.masterIgnoreRules = ignore();
     console.log('Ignore rules cleared.');
   }
 
@@ -116,23 +107,9 @@ class IgnoreRulesManager {
       return false;
     }
 
-    // Tier 1: Check .athignore rules first (highest precedence)
-    // The .test() method returns {ignored: boolean, unignored: boolean},
-    // allowing us to see if any rule had an opinion.
-    const athResult = this.athIgnoreRules.test(normalizedPath);
-    if (athResult.ignored || athResult.unignored) {
-      // An .athignore rule matched. This decision is final.
-      return athResult.ignored;
-    }
-
-    // Tier 2: Check .gitignore if enabled and Tier 1 had no opinion.
-    if (this.useGitignore) {
-      // We can use the simpler .ignores() here as there's no third tier.
-      return this.gitIgnoreRules.ignores(normalizedPath);
-    }
-
-    // Default: not ignored if no rules match.
-    return false;
+    // With a unified ruleset, a single check is sufficient.
+    // The useGitignore logic is handled during the loading phase.
+    return this.masterIgnoreRules.ignores(normalizedPath);
   }
 
   /**
@@ -142,6 +119,11 @@ class IgnoreRulesManager {
     absolutePath: string,
     isGitignore = false
   ): Promise<Pick<IgnoreFile, 'rules' | 'content'> | null> {
+    // --- PASTE THE NEW DEBUGGING CODE HERE ---
+    console.log(
+      `[READ DEBUG] Attempting to read ignore file at: ${absolutePath}`
+    );
+    // --- END OF DEBUGGING CODE ---
     try {
       const content = await fs.readFile(
         PathUtils.toPlatform(absolutePath),
@@ -151,8 +133,17 @@ class IgnoreRulesManager {
       if (isGitignore) {
         rules.add('.git/');
       }
+      // --- PASTE THE NEW DEBUGGING CODE HERE ---
+      console.log(`[READ DEBUG] Successfully read and parsed: ${absolutePath}`);
+      // --- END OF DEBUGGING CODE ---
       return { rules, content };
     } catch (error) {
+      // --- PASTE THE NEW DEBUGGING CODE HERE ---
+      console.error(
+        `[READ DEBUG] FAILED to read or parse: ${absolutePath}`,
+        error
+      );
+      // --- END OF DEBUGGING CODE ---
       return null;
     }
   }
@@ -291,6 +282,7 @@ class IgnoreRulesManager {
           entryRelativePath,
           true
         );
+
         if (ignoreTestPath) {
           if (pruningRules && pruningRules.ignores(ignoreTestPath)) {
             continue;
@@ -333,56 +325,54 @@ class IgnoreRulesManager {
    * @param directoryPath The project-relative path of the directory containing the ignore file.
    * @returns An array of transformed patterns ready to be added to the master ignore instance.
    */
+  // electron/ignoreRulesManager.ts
   private _transformPatterns(
     patterns: string[],
     directoryPath: string
   ): string[] {
-    if (directoryPath === '.') {
-      // Patterns in the root directory don't need transformation.
-      return patterns;
-    }
-
-    return patterns
+    // Clean the patterns first
+    const cleanedPatterns = patterns
       .map((rawPattern) => {
         const pattern = rawPattern.trim();
         if (pattern === '' || pattern.startsWith('#')) {
-          return null; // Ignore empty lines and comments
+          return null;
         }
-
-        let isNegated = false;
-        let finalPattern = pattern;
-
-        if (finalPattern.startsWith('!')) {
-          isNegated = true;
-          finalPattern = finalPattern.substring(1);
-        }
-
-        let transformed;
-        if (finalPattern.startsWith('/')) {
-          // A leading slash anchors the pattern to the ignore file's directory.
-          // e.g., `/foo` in `src/.gitignore` becomes `src/foo`.
-          transformed = PathUtils.joinUnix(
-            directoryPath,
-            finalPattern.substring(1)
-          );
-        } else if (!finalPattern.includes('/')) {
-          // A pattern without a slash matches in any subdirectory.
-          // e.g., `*.log` in `src/` becomes `src/**/*.log`.
-          transformed = PathUtils.joinUnix(directoryPath, '**', finalPattern);
-        } else {
-          // A pattern with a slash is relative to the ignore file's directory.
-          // e.g., `build/*.o` in `src/` becomes `src/build/*.o`.
-          transformed = PathUtils.joinUnix(directoryPath, finalPattern);
-        }
-
-        // Re-apply negation if it existed
-        if (isNegated) {
-          transformed = '!' + transformed;
-        }
-
-        return transformed;
+        return pattern;
       })
       .filter((p): p is string => p !== null);
+
+    if (directoryPath === '.') {
+      // Patterns in the root directory don't need path transformation.
+      return cleanedPatterns;
+    }
+
+    // For nested directories, transform the path of each cleaned pattern.
+    return cleanedPatterns.map((pattern) => {
+      let isNegated = false;
+      let finalPattern = pattern;
+
+      if (finalPattern.startsWith('!')) {
+        isNegated = true;
+        finalPattern = finalPattern.substring(1);
+      }
+
+      let transformed;
+      if (finalPattern.startsWith('/')) {
+        transformed = PathUtils.joinUnix(
+          directoryPath,
+          finalPattern.substring(1)
+        );
+      } else if (!finalPattern.includes('/')) {
+        transformed = PathUtils.joinUnix(directoryPath, '**', finalPattern);
+      } else {
+        transformed = PathUtils.joinUnix(directoryPath, finalPattern);
+      }
+
+      if (isNegated) {
+        return '!' + transformed;
+      }
+      return transformed;
+    });
   }
 
   // Load ignore rules: scan for all ignore files and sort them
@@ -471,67 +461,29 @@ class IgnoreRulesManager {
         ? this._sortIgnoreFilesByDepth(scanResults.gitignores)
         : [];
 
-      // Add rules to the master instances. The `ignore` library handles overrides correctly
-      // when rules are added in this shallow-to-deep order.
-      athignores.forEach((file) => {
-        const patterns = file.content.split('\n');
-        const transformed = this._transformPatterns(patterns, file.path);
-        this.athIgnoreRules.add(transformed);
-      });
-      if (athignores.length > 0) this.athRulesLoaded = true;
+      // Add rules to the master instance. The `ignore` library handles overrides correctly
+      // when rules are added in this order (Git then Athanor).
 
       if (this.useGitignore) {
         gitignores.forEach((file) => {
           const patterns = file.content.split('\n');
           const transformed = this._transformPatterns(patterns, file.path);
-          this.gitIgnoreRules.add(transformed);
+          this.masterIgnoreRules.add(transformed);
         });
-        if (gitignores.length > 0) this.gitRulesLoaded = true;
       }
 
-      // Debug logging for compiled ignore rules
-      if (DEBUG_IGNORE_RULES) {
-        console.log('--- [ATHANOR DEBUG] Compiled Ignore Rules ---');
-
-        console.log(
-          `\n[DEBUG] .athignore rules loaded: ${this.athRulesLoaded}`
-        );
-        if (athignores.length > 0) {
-          athignores.forEach((file) => {
-            console.log(
-              `  Source: ${file.path === '.' ? 'root' : file.path}/.athignore`
-            );
-            const content = file.content.trim();
-            console.log(`  Content:\n---\n${content}\n---`);
-          });
-        } else {
-          console.log('  No .athignore files were processed.');
-        }
-
-        console.log(
-          `\n[DEBUG] .gitignore processing enabled: ${this.useGitignore}`
-        );
-        if (this.useGitignore) {
-          console.log(
-            `[DEBUG] .gitignore rules loaded: ${this.gitRulesLoaded}`
-          );
-          if (gitignores.length > 0) {
-            gitignores.forEach((file) => {
-              console.log(
-                `  Source: ${file.path === '.' ? 'root' : file.path}/.gitignore`
-              );
-              const content = file.content.trim();
-              console.log(`  Content:\n---\n${content}\n---`);
-            });
-          } else {
-            console.log('  No .gitignore files were processed.');
-          }
-        }
-        console.log('\n--- [ATHANOR DEBUG] End of Ignore Rules ---');
-      }
+      athignores.forEach((file) => {
+        const patterns = file.content.split('\n');
+        const transformed = this._transformPatterns(patterns, file.path);
+        this.masterIgnoreRules.add(transformed);
+      });
 
       console.log(
-        `Ignore rule compilation complete. Processed ${athignores.length} .athignore files and ${gitignores.length} .gitignore files.`
+        `Ignore rule compilation complete. Processed ${
+          athignores.length
+        } .athignore files and ${
+          this.useGitignore ? gitignores.length : 0
+        } .gitignore files into a unified ruleset.`
       );
     } catch (error) {
       console.error('Error during ignore file scan:', error);

--- a/electron/ignoreRulesManager.ts
+++ b/electron/ignoreRulesManager.ts
@@ -100,6 +100,9 @@ class IgnoreRulesManager {
    * @param pathToCheck The project-relative path to check. Must be normalized for ignore checks (e.g., with a trailing slash for directories).
    * @returns True if the path should be ignored, false otherwise.
    */
+  // TODO: The current compiled-rules approach does NOT yet support
+  //       "forced inclusion" (!pattern) inside an already-ignored directory.
+  //       This may be addressed in a future release.
   ignores(pathToCheck: string): boolean {
     if (!pathToCheck || typeof pathToCheck !== 'string') {
       return false; // Invalid input
@@ -176,10 +179,7 @@ class IgnoreRulesManager {
 
     // Check for .athignore and read it if it exists
     if (entries.includes('.athignore')) {
-      const athignorePath = PathUtils.joinUnix(
-        absoluteStartDir,
-        '.athignore'
-      );
+      const athignorePath = PathUtils.joinUnix(absoluteStartDir, '.athignore');
       const athignoreData = await this._readIgnoreFile(athignorePath);
       if (athignoreData) {
         athignores.push({
@@ -194,10 +194,7 @@ class IgnoreRulesManager {
 
     // Check for .gitignore and read it if it exists
     if (useGitignore && entries.includes('.gitignore')) {
-      const gitignorePath = PathUtils.joinUnix(
-        absoluteStartDir,
-        '.gitignore'
-      );
+      const gitignorePath = PathUtils.joinUnix(absoluteStartDir, '.gitignore');
       const gitignoreData = await this._readIgnoreFile(gitignorePath, true);
       if (gitignoreData) {
         gitignores.push({
@@ -234,7 +231,8 @@ class IgnoreRulesManager {
       startDir === '.'
         ? this.baseDir
         : PathUtils.joinUnix(this.baseDir, startDir);
-    if (!absoluteStartDir) return { athignores: allAthIgnores, gitignores: allGitIgnores };
+    if (!absoluteStartDir)
+      return { athignores: allAthIgnores, gitignores: allGitIgnores };
     const platformStartDir = PathUtils.toPlatform(absoluteStartDir);
 
     try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "athanor",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "bugs": {
     "url": "https://github.com/lacerbi/athanor/issues"
   },


### PR DESCRIPTION
# refactor: Implement Git-Consistent Nested Ignore Rule Handling

## Summary

This pull request refactors the `IgnoreRulesManager` to correctly process nested and path-relative rules from `.gitignore` and `.athignore` files. The previous implementation did not properly scope patterns found in subdirectories, leading to behavior inconsistent with Git and causing files to be incorrectly included or excluded.

This work builds on previous performance improvements by ensuring the ignore logic is not only fast but also correct according to well-established standards.

## Changes Made

-   **The Problem:** The core issue was that patterns in nested ignore files (e.g., in `src/.gitignore`) were not being treated as relative to that file's location. A pattern like `/dist` was treated as a global rule rather than being anchored to the `src/` directory, leading to incorrect file tree filtering.

-   **The Solution: Path-Relative Transformation:**
    -   A new transformation step (`_transformPatterns`) has been implemented. It processes every pattern from every discovered ignore file and converts it into an absolute, root-relative path.
    -   For example, a rule `/logs` inside `server/.gitignore` is now correctly interpreted as `server/logs`. A non-anchored rule like `*.tmp` becomes `server/**/*.tmp`, scoping it to the sub-directory and its children as expected.

-   **Refactored Scanning Process:** To support this new logic, the directory scanning method (`_scanForIgnoreFiles`) was refactored to cleanly separate the *discovery* of ignore files from the *compilation* of their rules. This makes the logic more robust and easier to maintain.

-   **Updated Tests:** The unit tests for `ignoreRulesManager` have been significantly expanded to assert the correct behavior for various nested and path-relative scenarios, ensuring the new implementation is reliable.

## Testing Done

-   Manually verified the changes against repositories with complex, nested `.gitignore` files, confirming that files are now hidden from the explorer in a manner that matches `git status`.
-   All new and existing automated tests in `ignoreRulesManager.test.ts` are passing.